### PR TITLE
Fix README spelling/name error

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -326,7 +326,7 @@ parseCmdAdd =
           "Examples:" Opts.<$$>
           "" Opts.<$$>
           "  niv add stedolan/jq" Opts.<$$>
-          "  niv add NixOS/nixpkgs-channel -n nixpkgs -b nixos-18.09" Opts.<$$>
+          "  niv add NixOS/nixpkgs-channels -n nixpkgs -b nixos-18.09" Opts.<$$>
           "  niv add my-package -v alpha-0.1 -t http://example.com/archive/<version>.zip"
       ]
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Available commands:
 Examples:
 
   niv add stedolan/jq
-  niv add NixOS/nixpkgs-channel -n nixpkgs -b nixos-18.09
+  niv add NixOS/nixpkgs-channels -n nixpkgs -b nixos-18.09
   niv add my-package -v alpha-0.1 -t http://example.com/archive/<version>.zip
 
 Usage: niv add [-n|--name NAME] PACKAGE ([-a|--attribute KEY=VAL] |


### PR DESCRIPTION
"NixOS/nixpkgs-channel" does not actually exist, the correct repo would be "NixOS/nixpkgs-channels"