### PR TITLE
Support restricted evaluation mode

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -611,6 +611,8 @@ initNixSourcesNixContent = [s|
 # A record, from name to path, of the third-party packages
 with rec
 {
+  pkgs = import <nixpkgs> {};
+
   sources = builtins.fromJSON (builtins.readFile ./sources.json);
 
   # fetchTarball version that is compatible between all the sources of Nix
@@ -630,8 +632,8 @@ with rec
       then builtins.getAttr "type" spec
       else "tarball";
     in builtins.getAttr fetcherName {
-      "tarball" = builtins.fetchTarball;
-      "file" = builtins.fetchurl;
+      "tarball" = pkgs.fetchzip;
+      "file" = pkgs.fetchurl;
     };
 };
 # NOTE: spec must _not_ have an "outPath" attribute

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Examples:
 
 Usage: niv add [-n|--name NAME] PACKAGE ([-a|--attribute KEY=VAL] |
                [-b|--branch BRANCH] | [-o|--owner OWNER] | [-r|--repo REPO] |
-               [-v|--version VERSION] | [-t|--template URL])
+               [-v|--version VERSION] | [-t|--template URL] | [-T|--type TYPE])
   Add dependency
 
 Available options:
@@ -226,6 +226,9 @@ Available options:
   -v,--version VERSION     Equivalent to --attribute version=<VERSION>
   -t,--template URL        Used during 'update' when building URL. Occurrences
                            of <foo> are replaced with attribute 'foo'.
+  -T,--type TYPE           The type of the URL target. The value can be either
+                           'file' or 'tarball'. If not set, the value is
+                           inferred from the suffix of the URL.
   -h,--help                Show this help text
 
 ```
@@ -241,7 +244,7 @@ Examples:
 
 Usage: niv update [PACKAGE] ([-a|--attribute KEY=VAL] | [-b|--branch BRANCH] |
                   [-o|--owner OWNER] | [-r|--repo REPO] | [-v|--version VERSION]
-                  | [-t|--template URL])
+                  | [-t|--template URL] | [-T|--type TYPE])
   Update dependencies
 
 Available options:
@@ -252,6 +255,9 @@ Available options:
   -v,--version VERSION     Equivalent to --attribute version=<VERSION>
   -t,--template URL        Used during 'update' when building URL. Occurrences
                            of <foo> are replaced with attribute 'foo'.
+  -T,--type TYPE           The type of the URL target. The value can be either
+                           'file' or 'tarball'. If not set, the value is
+                           inferred from the suffix of the URL.
   -h,--help                Show this help text
 
 ```


### PR DESCRIPTION
When the Nix restricted evaluation mode is enable, `builtins.fetch*`
functions can no longer be used. So, instead of using `builtins`
fetchers, we use fetchers from nixpkgs.

Note Hydra enables the restricted evaluation mode by default.