### PR TITLE
sources.nix: Use the fetcher instead of creating derivations

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -631,18 +631,9 @@ with rec
       "file" = pkgs.fetchurl;
     };
 };
-# NOTE: spec must _not_ have an "outPath" attribute
-mapAttrs (_: spec:
-  if builtins.hasAttr "outPath" spec
-  then abort
-    "The values in sources.json should not have an 'outPath' attribute"
-  else
-    if builtins.hasAttr "url" spec && builtins.hasAttr "sha256" spec
-    then
-      spec //
-      { outPath = getFetcher spec { inherit (spec) url sha256; } ; }
-    else spec
-  ) sources
+mapAttrs
+  (_: spec: getFetcher spec { inherit (spec) url sha256; })
+  sources
 |]
 
 -- | @nix/default.nix@

--- a/Main.hs
+++ b/Main.hs
@@ -632,7 +632,7 @@ with rec
     };
 };
 mapAttrs
-  (_: spec: getFetcher spec { inherit (spec) url sha256; })
+  (_: spec: getFetcher spec { inherit (spec) url sha256; } // { niv = spec; })
   sources
 |]
 


### PR DESCRIPTION
The created derivations were not enough well created to be handled by
Hydra as a package [1]. Basically, Hydra recurses on the provided
attribute set to figure out which attribute is a derivation. If an
attribute set contains an attribut `type="derivation"`, it is consider
as a derivation. But Hydra requires also more attributes such as a
`name`, `system`...

Since we are now using fetchers from `nixpkgs`, we can directly use
them since they return a derviation.

[1] I add all Niv derivations as packages in Hydra in order to copy
them to the binary cache since it is no done at evaluation time.