### PR TITLE
WIP: Add docker fetcher based on Skopeo

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -17,3 +17,4 @@ executable:
         - mtl
         - optparse-applicative
         - unordered-containers
+        - temporary


### PR DESCRIPTION
This fetcher relies on Skopeo to fetch image metadatas, download the image
in order to get its sha256 and to prefetch it.

To use it:
```
niv add alpine --type docker -a name=alpine -a tag=latest
nix-build  nix/sources.nix -A alpine
```

Important note: this is WIP and not really tested yet:/

The main objective of this PR is to discuss the implementation: should we create `PackageSpec` subtypes (one per fetcher for instance) in order to be able to specialize `PackageSpec` functions to make them more understandable.

Also, I think it would be better to first introduce the `niv add` subcommands (ie. `niv add <github|docker|...>`). This is coming soon.