### PR TITLE
Don't drop nulls

### DIFF
--- a/src/Niv/Cli.hs
+++ b/src/Niv/Cli.hs
@@ -90,19 +90,7 @@ newtype PackageSpec = PackageSpec { unPackageSpec :: Aeson.Object }
 
 -- | Simply discards the 'Freedom'
 attrsToSpec :: Attrs -> PackageSpec
-attrsToSpec = PackageSpec . dropNulls . fmap snd
-  where
-    dropNulls
-      :: HMS.HashMap T.Text Aeson.Value
-      -> HMS.HashMap T.Text Aeson.Value
-    dropNulls = HMS.mapMaybe $ \case
-      x@Aeson.Object{} -> Just x
-      x@Aeson.Array{} -> Just x
-      x@Aeson.String{} -> Just x
-      x@Aeson.Number{} -> Just x
-      x@Aeson.Bool{} -> Just x
-      Aeson.Null -> Nothing
-
+attrsToSpec = PackageSpec . fmap snd
 
 parsePackageSpec :: Opts.Parser PackageSpec
 parsePackageSpec =

--- a/tests/expected/niv-init.json
+++ b/tests/expected/niv-init.json
@@ -1,5 +1,6 @@
 {
     "nixpkgs": {
+        "homepage": null,
         "url": "http://localhost:3333/NixOS/nixpkgs-channels/archive/571b40d3f50466d3e91c1e609d372de96d782793.tar.gz",
         "owner": "NixOS",
         "branch": "nixos-18.09",


### PR DESCRIPTION
Turns out that not storing the `null` values is a problem as `niv` will always try to re-download the attributes.

CC @michaelpj 