### PR TITLE
Keep the nix ssl cert file variable when running the tests

### DIFF
--- a/script/test
+++ b/script/test
@@ -4,6 +4,8 @@
 #!nix-shell -p nix
 #!nix-shell --pure
 #!nix-shell --keep SSL_CERT_FILE
+#!nix-shell --keep NIX_SSL_CERT_FILE
+
 
 set -euo pipefail
 


### PR DESCRIPTION
This will allow us to fetch binaries from cache.nixos.org without the dreaded

```
warning: unable to download 'https://cache.nixos.org/nix-cache-info': 
SSL peer certificate or SSH remote key was not OK (60)
```
error message.