### PR TITLE
Add completions and disable profiling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,9 @@ jobs:
             until bash <(curl https://nixos.org/nix/install)
             do
               echo "Nix install failed, retrying"
-              rm -rf /nix
+              sudo rm -rf /nix
+              sudo mkdir -p /nix
+              sudo chown circleci /nix
             done
             echo '. /home/circleci/.nix-profile/etc/profile.d/nix.sh' >> $BASH_ENV
 

--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,12 @@ with rec
   niv-source = gitignoreSource ./.;
   haskellPackages = pkgs.haskellPackages.override
     { overrides = _: haskellPackages:
-        { niv = haskellPackages.callCabal2nix "niv" niv-source {}; };
+        { niv =
+            pkgs.haskell.lib.disableExecutableProfiling (
+            pkgs.haskell.lib.disableLibraryProfiling (
+            pkgs.haskell.lib.generateOptparseApplicativeCompletion "niv" (
+            haskellPackages.callCabal2nix "niv" niv-source {})));
+        };
     };
 
   niv = haskellPackages.niv;


### PR DESCRIPTION
Adds completions for shells using the nixpkgs lib functions, and turns off profiling for our libraries and executables to speed up building.