### PR TITLE
Allow to configure niv directory path

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The following environment variables are read by `niv`:
 
 | Name            | Note |
 | --------------- | ---- |
+| NIV_DIR    | Directory where sources.nix and sources.json will be located, defaults to "nix". |
 | GITHUB_TOKEN    | When set, the value is used to authenticate GitHub API requests. |
 | GITHUB_HOST     | The GitHub host to use when fetching packages. Port may be appended here. |
 | GITHUB_API_HOST | The host used when performing GitHub API requests. Use `GITHUB_API_PORT` for specifying the port. |

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -52,6 +52,7 @@ The following environment variables are read by `niv`:
 
 | Name            | Note |
 | --------------- | ---- |
+| NIV_DIR    | Directory where sources.nix and sources.json will be located, defaults to "nix". |
 | GITHUB_TOKEN    | When set, the value is used to authenticate GitHub API requests. |
 | GITHUB_HOST     | The GitHub host to use when fetching packages. Port may be appended here. |
 | GITHUB_API_HOST | The host used when performing GitHub API requests. Use `GITHUB_API_PORT` for specifying the port. |

--- a/src/Niv/Cli.hs
+++ b/src/Niv/Cli.hs
@@ -20,7 +20,9 @@ import Data.String.QQ (s)
 import Niv.Logger
 import Niv.GitHub
 import Niv.Update
+import System.Environment (lookupEnv)
 import System.Exit (ExitCode(ExitSuccess))
+import System.IO.Unsafe (unsafePerformIO)
 import System.FilePath ((</>), takeDirectory)
 import System.Process (readProcessWithExitCode)
 import UnliftIO
@@ -579,7 +581,9 @@ warnIfOutdated = do
 
 -- | @nix/sources.nix@
 pathNixSourcesNix :: FilePath
-pathNixSourcesNix = "nix" </> "sources.nix"
+pathNixSourcesNix = unsafePerformIO $ do
+    nivPath <- lookupEnv "NIV_DIR"
+    pure $ maybe "nix" id nivPath </> "sources.nix"
 
 -- | Glue code between nix and sources.json
 initNixSourcesNixContent :: B.ByteString
@@ -587,7 +591,9 @@ initNixSourcesNixContent = $(embedFile "nix/sources.nix")
 
 -- | @nix/sources.json"
 pathNixSourcesJson :: FilePath
-pathNixSourcesJson = "nix" </> "sources.json"
+pathNixSourcesJson = unsafePerformIO $ do
+    nivPath <- lookupEnv "NIV_DIR"
+    pure $ maybe "nix" id nivPath </> "sources.json"
 
 -- | Empty JSON map
 initNixSourcesJsonContent :: B.ByteString

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -122,4 +122,13 @@ in pkgs.runCommand "test"
     cat nix/sources.json | jq -e '.foo | .url == "localhost:3333/foo-v1"'
     echo "*** ok."
     cp nix/sources.json $out
+
+    echo -e "\n*** NIV_DIR=nix2 niv init"
+    NIV_DIR=nix2 niv init
+    diff -h ${./expected/niv-init.json} nix2/sources.json || \
+      (echo "Mismatched sources.json"; \
+      echo "Reference: tests/expected/niv-init.json"; \
+      exit 1)
+
+    echo "*** ok."
   ''


### PR DESCRIPTION
New NIV_DIR environment variable configures a path to a directory
where niv will manage sources.{nix,json} files.