### PR TITLE
Add a shortcut attribute for 'rev'

### DIFF
--- a/src/Niv/Cli.hs
+++ b/src/Niv/Cli.hs
@@ -142,7 +142,7 @@ parsePackageSpec =
     -- Shortcuts for common attributes
     shortcutAttributes :: Opts.Parser (T.Text, T.Text)
     shortcutAttributes = foldr (<|>) empty $ mkShortcutAttribute <$>
-      [ "branch", "owner", "repo", "version" ]
+      [ "branch", "owner", "repo", "version", "rev" ]
 
     -- TODO: infer those shortcuts from 'Update' keys
     mkShortcutAttribute :: T.Text -> Opts.Parser (T.Text, T.Text)


### PR DESCRIPTION
I find 90% of the time when I'm updating a pin I want to go to a
specific rev. There's already a shortcut attribute for `version`, which
comes up less often (since it's not used in the most common case of
fetching git repos).