### PR TITLE
Release 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.4] 2019-12-01
+### Added
+* Experimental support for `add` subcommands, in particular `niv add git`
+## Changed
+* Various error message fixes
+
 ## [0.2.3] 2019-11-28
 ### Added
 * A new CLI option (`-s`) reads attributes as raw strings.

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ $ niv update ghc -v 8.6.2
 ```
 niv - dependency manager for Nix projects
 
-version: 0.2.3
+version: 0.2.4
 
 Usage: niv COMMAND
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: niv
-version: 0.2.3
+version: 0.2.4
 license: MIT
 author: Nicolas Mattia <nicolas@nmattia.com>
 maintainer: Nicolas Mattia <nicolas@nmattia.com>


### PR DESCRIPTION
## [0.2.4] 2019-12-01
### Added
* Experimental support for `add` subcommands, in particular `niv add git`
## Changed
* Various error message fixes