### PR TITLE
Fix compatibility with nix-build

### DIFF
--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -8,13 +8,13 @@ let
 
   fetch_file = spec:
     if spec.builtin or true then
-      builtins_fetchurl { inherit (spec) url sha256; }
+      pathToDerivation (builtins_fetchurl { inherit (spec) url sha256; })
     else
       pkgs.fetchurl { inherit (spec) url sha256; };
 
   fetch_tarball = spec:
     if spec.builtin or true then
-      builtins_fetchTarball { inherit (spec) url sha256; }
+      pathToDerivation (builtins_fetchTarball { inherit (spec) url sha256; })
     else
       pkgs.fetchzip { inherit (spec) url sha256; };
 
@@ -88,6 +88,14 @@ let
     else if spec.type == "builtin-url" then fetch_builtin-url spec
     else
       abort "ERROR: niv spec ${name} has unknown type ${builtins.toJSON spec.type}";
+
+  pathToDerivation = outPath: {
+    name = "source";
+    type = "derivation";
+    system = builtins.currentSystem;
+    outputName = "out";
+    inherit outPath;
+  };
 
   # Ports of functions for older nix versions
 

--- a/src/Niv/Sources.hs
+++ b/src/Niv/Sources.hs
@@ -136,6 +136,7 @@ data SourcesNixVersion
   | V10
   | V11
   | V12
+  | V13
   deriving stock (Bounded, Enum, Eq)
 
 -- | A user friendly version
@@ -153,6 +154,7 @@ sourcesVersionToText = \case
     V10 -> "10"
     V11 -> "11"
     V12 -> "12"
+    V13 -> "13"
 
 latestVersionMD5 :: T.Text
 latestVersionMD5 = sourcesVersionToMD5 maxBound
@@ -177,6 +179,7 @@ sourcesVersionToMD5 = \case
     V10 -> "d8625c0a03dd935e1c79f46407faa8d3"
     V11 -> "8a95b7d93b16f7c7515d98f49b0ec741"
     V12 -> "2f9629ad9a8f181ed71d2a59b454970c"
+    V13 -> "d3d8cddd7016df60858360ac091179ed"
 
 -- | The MD5 sum of ./nix/sources.nix
 sourcesNixMD5 :: IO T.Text


### PR DESCRIPTION
This fixes #154 by making built-in functions compatible with nixpkgs ones (by making `outPath` appear to be a derivation)

This is a hack created due to lack of other solutions.