### PR TITLE
Rename sourcesFile to sourcesJson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.2.8] 2019-12-00
+## Changed
+* Fixed message in `niv init` with custom `sources.json`
+
 ## [0.2.7] 2019-12-08
 ## Added
 * Support for custom path `sources.json` with `--sources-json`

--- a/README.md
+++ b/README.md
@@ -201,10 +201,10 @@ niv - dependency manager for Nix projects
 
 version: 0.2.7
 
-Usage: niv [-s|--sources-json FILE] COMMAND
+Usage: niv [-s|--sources-file FILE] COMMAND
 
 Available options:
-  -s,--sources-json FILE   Use FILE instead of nix/sources.json
+  -s,--sources-file FILE   Use FILE instead of nix/sources.json
   -h,--help                Show this help text
 
 Available commands:

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -124,10 +124,10 @@ let
 
   # The "config" used by the fetchers
   mkConfig =
-    { sourcesJson ? ./sources.json
+    { sourcesFile ? ./sources.json
     }: rec {
       # The sources, i.e. the attribute set of spec name to spec
-      sources = builtins.fromJSON (builtins.readFile sourcesJson);
+      sources = builtins.fromJSON (builtins.readFile sourcesFile);
       # The "pkgs" (evaluated nixpkgs) to use for e.g. non-builtin fetchers
       pkgs = mkPkgs sources;
     };

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -124,10 +124,10 @@ let
 
   # The "config" used by the fetchers
   mkConfig =
-    { sourcesFile ? ./sources.json
+    { sourcesJson ? ./sources.json
     }: rec {
       # The sources, i.e. the attribute set of spec name to spec
-      sources = builtins.fromJSON (builtins.readFile sourcesFile);
+      sources = builtins.fromJSON (builtins.readFile sourcesJson);
       # The "pkgs" (evaluated nixpkgs) to use for e.g. non-builtin fetchers
       pkgs = mkPkgs sources;
     };

--- a/src/Niv/Cli.hs
+++ b/src/Niv/Cli.hs
@@ -69,7 +69,7 @@ cli = do
       ]
     parseFindSourcesJson =
       AtPath <$> Opts.strOption (
-        Opts.long "sources-json" <>
+        Opts.long "sources-file" <>
         Opts.short 's' <>
         Opts.metavar "FILE" <>
         Opts.help "Use FILE instead of nix/sources.json"
@@ -154,7 +154,7 @@ cmdInit = do
                   , "You are using a custom path for sources.json."
                   ]
             , "  You need to configure the sources.nix to use " <> tbold (T.pack fp) <> ":"
-            , tbold "      import sources.nix { sourcesJson = PATH ; }; "
+            , tbold "      import sources.nix { sourcesFile = PATH ; }; "
             , T.unwords
                   [ "  where", tbold "PATH", "is the relative path from sources.nix to"
                   , tbold (T.pack fp) <> "." ]


### PR DESCRIPTION
See https://github.com/nmattia/niv/pull/159#issuecomment-563002902.  I opted to rename the option rather than updating the docs because the cli option is `--sources-json` and so using an option `sourcesJson` is more obvious than keeping it as `sourcesFile`.