### PR TITLE
Distribute sources.nix file with package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [0.2.8] 2019-12-00
+## Added
+* Package `sources.nix` with `niv` package
 ## Changed
 * Fixed message in `niv init` with custom `sources.json`
 

--- a/default.nix
+++ b/default.nix
@@ -58,7 +58,13 @@ with rec
     };
   };
 
-  niv = haskellPackages.niv;
+  niv = haskellPackages.niv.overrideAttrs (oldAttrs: {
+    postInstall = ''
+      ${oldAttrs.postInstall}
+      mkdir -p $out/share/niv
+      cp $src/nix/sources.nix $out/share/niv
+    '';
+  });
 
   niv-sdist = pkgs.haskell.lib.sdistTarball niv;
 
@@ -68,7 +74,7 @@ with rec
     in
       pkgs.writeScript "cabal-upload"
         ''
-          #!${pkgs.stdenv.shell}
+        #!${pkgs.stdenv.shell}
           cabal upload "$@" "${niv-sdist}/niv-${niv-version}.tar.gz"
         '';
 


### PR DESCRIPTION
This PR just adds the `sources.nix` file to the niv package distribution so that it can be referenced instead of copied into projects.  This was briefly discussed in #159, I'm not sure if you really wanted to go in this direction @nmattia but I figured I'd put in this PR to help out just in case.