### PR TITLE
ci: add nixpkgs-fmt check

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -145,6 +145,7 @@ with rec
   # version from `package.yaml` and create a dummy module that we inject in the
   # `ghci` command.
   niv-devshell = haskellPackages.shellFor {
+    buildInputs = [ pkgs.nixpkgs-fmt ];
     packages = ps: [ ps.niv ];
     shellHook = ''
       repl_for() {

--- a/script/test
+++ b/script/test
@@ -2,6 +2,7 @@
 #!nix-shell -i bash
 #!nix-shell -I nixpkgs=./nix
 #!nix-shell -p nix
+#!nix-shell -p nixpkgs-fmt
 #!nix-shell --pure
 
 unset NIX_SSL_CERT_FILE
@@ -31,5 +32,13 @@ fi
 
 # Build and create a root
 nix-build ${nixargs[@]}
+
+echo "Formatting"
+
+if ! nixpkgs-fmt --check . ; then
+  echo
+  echo 'run `nixpkgs-fmt .` to fix this issue'
+  exit 1
+fi
 
 echo "all good"


### PR DESCRIPTION
Avoid formatting regressions.

Assuming a project uses both niv and nixpkgs-fmt, we want to avoid re-formatting nix/sources.nix. Otherwise niv will complain about it being out of date.