### PR TITLE
Only build static executable in top-level niv attribute

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -46,11 +46,13 @@ with rec
   haskellPackages = pkgs.haskellPackages.override {
     overrides = _: haskellPackages: {
       niv =
-        pkgs.haskell.lib.failOnAllWarnings (
-          pkgs.haskell.lib.disableExecutableProfiling (
-            pkgs.haskell.lib.disableLibraryProfiling (
-              pkgs.haskell.lib.generateOptparseApplicativeCompletion "niv" (
-                haskellPackages.callCabal2nix "niv" niv-source {}
+        pkgs.haskell.lib.justStaticExecutables (
+          pkgs.haskell.lib.failOnAllWarnings (
+            pkgs.haskell.lib.disableExecutableProfiling (
+              pkgs.haskell.lib.disableLibraryProfiling (
+                pkgs.haskell.lib.generateOptparseApplicativeCompletion "niv" (
+                  haskellPackages.callCabal2nix "niv" niv-source {}
+                )
               )
             )
           )


### PR DESCRIPTION
This reduces the closure size by about 2G

Closes #178 

@novoxudonoser thanks for bringing this up!