### PR TITLE
Don't needlessly evaluate <nixpkgs>

### DIFF
--- a/src/Niv/Sources.hs
+++ b/src/Niv/Sources.hs
@@ -146,6 +146,7 @@ data SourcesNixVersion
   | V13
   | V14
   | V15
+  | V16
   deriving stock (Bounded, Enum, Eq)
 
 -- | A user friendly version
@@ -166,6 +167,7 @@ sourcesVersionToText = \case
     V13 -> "13"
     V14 -> "14"
     V15 -> "15"
+    V16 -> "16"
 
 latestVersionMD5 :: T.Text
 latestVersionMD5 = sourcesVersionToMD5 maxBound
@@ -193,6 +195,7 @@ sourcesVersionToMD5 = \case
     V13 -> "5e23c56b92eaade4e664cb16dcac1e0a"
     V14 -> "b470e235e7bcbf106d243fea90b6cfc9"
     V15 -> "dc11af910773ec9b4e505e0f49ebcfd2"
+    V16 -> "2d93c52cab8e960e767a79af05ca572a"
 
 -- | The MD5 sum of ./nix/sources.nix
 sourcesNixMD5 :: IO T.Text


### PR DESCRIPTION
This changes the logic to make sure the first `if` branch -- which pulls nixpkgs from sources.json -- is evaluated first. Moreover the `<nixpkgs>` check is changed to avoid actually evaluating `<nixpkgs>`.

Closes #143 