### PR TITLE
Remove the niv-test executable

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -196,9 +196,6 @@ rec
   tests-github = pkgs.callPackage ./tests/github { inherit niv; };
   tests-git = pkgs.callPackage ./tests/git { inherit niv; };
 
-  niv-test = pkgs.runCommand "niv-test" { buildInputs = [ niv ]; }
-    "niv-test && touch $out";
-
   readme = pkgs.writeText "README.md" (
     let
       template = builtins.readFile ./README.tpl.md;

--- a/package.yaml
+++ b/package.yaml
@@ -57,7 +57,9 @@ executables:
         source-dirs: app
         dependencies:
             - niv
-    niv-test:
+
+tests:
+    unit:
         main: NivTest.main
         source-dirs: app
         dependencies:

--- a/script/test
+++ b/script/test
@@ -27,7 +27,7 @@ if [[ ! $OSTYPE =~ darwin ]]; then
 else
     echo "Testing on darwin"
     echo "Not enabling sandbox, not running integration"
-    targets+=("-A" "niv-test")
+    targets+=("-A" "niv")
 fi
 
 # Build and create a root


### PR DESCRIPTION
This moves the tests into a `tests` section of the `package.yaml`. Otherwise, the `niv-test` is shipped with the actual executable.

Closes #182 