### PR TITLE
Fix foo to get back static executable

### DIFF
--- a/foo/default.nix
+++ b/foo/default.nix
@@ -60,7 +60,7 @@
       in
         haskellPackages.callPackage (
           { mkDerivation }:
-            haskellPackages.mkDerivation {
+            mkDerivation {
               pname = spec.name;
               version = spec.version;
               inherit src;


### PR DESCRIPTION
The `overrideCabal` mechanism, used to provide static executables, requires the `mkDerivation` argument in `callPackage` to be actually used. `foo/default.nix` currently ignores this argument, so this broke the static executable override.