### PR TITLE
Learn to expand url template at runtime to inject secrets

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -41,7 +41,7 @@ with rec
     "^src.*.hs$"
     "^README.md$"
     "^nix$"
-    "^nix.sources.nix$"
+    "^nix.sources.*.nix$"
   ];
 
   haskellPackages = pkgs.haskellPackages.override {

--- a/nix/sources.lib.nix
+++ b/nix/sources.lib.nix
@@ -1,0 +1,184 @@
+{ nixpkgs ? import <nixpkgs> { }
+}:
+
+with nixpkgs;
+
+rec {
+
+  build-replacement-mapping =
+    #
+    # Replace occurences of <`prefix`:KEY> with VAL in `tpl` where
+    # KEY and VAL are from `mapping`
+    #
+    # tpl     = the template string
+    # prefix  = string keying the replacement
+    # mapping = mapping from some key to the replacement value
+    #
+    # Ex:
+    #   prefix  = "env"
+    #   mapping = { HELLO = "WORLD"; }
+    #
+    #   ==> { from = [ "<env:HELLO>" ]; to = [ "WORLD" ]; }
+
+    { prefix            # :: String
+    , mapping           # :: { KEY = VAL }
+    , skip-keys ? [ ]   # :: [String] == mapping keys to exclude
+    , delim_left ? "<"  #
+    , delim_right ? ">" #
+    , sep ? ":"         # separator between `prefix` and KEY
+    }: # ==> { from :: [String];  to :: [String]; }
+
+      with builtins;
+      with lib;
+      let
+        cleaned-mapping = filterAttrs (k: v: !elem k skip-keys) mapping;
+      in
+      zipAttrs
+        (mapAttrsToList
+          (k: v:
+          {
+            from = "${delim_left}${prefix}${sep}${k}${delim_right}";
+            to = v;
+          }
+          )
+          cleaned-mapping);
+
+
+  getEnv = name:
+    #
+    # :: String -> null or String
+    #
+    # a version of builtins.getEnv that returns null on failure
+    #
+    let val = builtins.getEnv name;
+    in if val == "" then null else val;
+
+
+  generate-replacements = spec:
+    #
+    # :: Spec -> ReplacementMapping
+    #
+    let
+      inherit (lib) elem filterAttrs flatten genAttrs isString mapAttrs zipAttrs;
+      ignore-keys = [ "url_template" "url" "sha256" "type" ];
+      var-mapping = build-replacement-mapping { prefix = ""; sep = ""; mapping = filterAttrs (k: v: !elem k ignore-keys && isString v) spec; };
+      runtime-env = build-replacement-mapping { prefix = "env"; mapping = genAttrs (spec.runtime.env or [ ]) getEnv; };
+    in
+    mapAttrs (_: n: flatten n) (zipAttrs [ var-mapping runtime-env ]);
+
+
+  apply-templates = attrName: spec:
+    #
+    # :: String -> Spec -> String
+    #
+    # Expand the templates of the given `attrName` in `spec`
+    #
+    let
+      inherit (builtins) getAttr;
+      transform = generate-replacements spec;
+      value = spec."${attrName}" or (builtins.trace "ERROR: unknown attribute '${attrName}' in spec ${asString spec}" (getAttr attrName spec));
+    in
+    lib.replaceStrings transform.from transform.to value;
+
+
+  asString = val:
+    #
+    # :: Any -> String
+    #
+    # Like `builtins.toString` but tries to not yell.
+    #
+    # Will `trace` if no known prettyfier for value's type.
+    #
+    with builtins;
+    if isAttrs val then toJSON val
+    else if isBool val then if val then "true" else "false"
+    else if isFloat val then toString val
+    else if isInt val then toString val
+    else if isList val then "[ ${toString (map asString val)} ]"
+    else if isNull val then "<null>"
+    else if isString val then val
+    else trace "asString: Unknown type: ${typeOf val}" "<<${typeOf val}>>";
+
+
+  elaborate-url = spec:
+    #
+    # :: Spec -> Spec
+    #
+    # If no url is provided, expand the url template, otherwise NoOp
+    #
+    spec // { url = spec.url or (apply-templates "url_template" spec); };
+
+
+  tests =
+    #
+    # Test the functions here.  This is an AttrSet of test name to
+    # result, with logging done using trace
+    #
+    let
+      check = expected: actual:
+        if expected == actual
+        then { passed = true; msg = null; }
+        else { passed = false; msg = "Expected: ${asString expected} got ${asString actual}"; };
+      report = name: result:
+        #
+        # Report if a test passed or failed.  Failures trigger an
+        # abort for non-zero exit.
+        #
+        let val = if result.passed then result else abort result.msg;
+        in builtins.trace "Test ${name} ${ if result.passed then "passed" else "failed"}" val;
+    in
+    lib.mapAttrs report
+      {
+        build-replacement-mapping =
+          check
+            { from = [ "<env:HELLO>" ]; to = [ "WORLD" ]; }
+            (build-replacement-mapping { prefix = "env"; mapping = { HELLO = "WORLD"; }; });
+
+        generate-replacements =
+          check
+            {
+              from = [ "<domain>" "<env:HELLO>" ];
+              to = [ "foo.bar" "world" ];
+            }
+            (generate-replacements
+              {
+                url_template = "http://<domain>.tld/<env:HELLO>.whatever.ext";
+                domain = "foo.bar";
+                runtime.env = [ "HELLO" ]; # export HELLO=world required by parent process
+              }
+            );
+
+        apply-templates =
+          check
+            "http://foo.bar.tld/world.whatever.ext"
+            (apply-templates "url_template"
+              {
+                url_template = "http://<domain>.tld/<env:HELLO>.whatever.ext";
+                domain = "foo.bar";
+                runtime.env = [ "HELLO" ]; # export HELLO=world required by parent process
+              }
+            );
+
+        elaborate-url-is-noop =
+          let spec = { url = "hello-world"; hello = "hello"; world = "world"; url_template = "<hello>-<world>"; }; in
+          check
+            spec
+            (elaborate-url spec);
+
+        elaborate-url-updates =
+          let spec = { hello = "hello"; world = "world"; url_template = "<hello>-<world>"; }; in
+          check
+            (spec // { url = "hello-world"; })
+            (elaborate-url spec);
+
+        asString-bool-true = check "true" (asString true);
+        asString-bool-false = check "false" (asString false);
+        asString-float = check "42.000000" (asString 42.0);
+        asString-int = check "42" (asString 42);
+        asString-list-of-int = check "[ 42 ]" (asString [ 42 ]);
+        asString-null = check "<null>" (asString null);
+        asString-string = check "wat" (asString "wat");
+
+
+      };
+}

--- a/src/Niv/Sources.hs
+++ b/src/Niv/Sources.hs
@@ -213,6 +213,10 @@ sourcesNixMD5 = T.pack . show . MD5.md5 <$> BL8.readFile pathNixSourcesNix
 pathNixSourcesNix :: FilePath
 pathNixSourcesNix = "nix" </> "sources.nix"
 
+-- | @nix/sources.lib.nix@
+pathNixSourcesLibNix :: FilePath
+pathNixSourcesLibNix = "nix" </> "sources.lib.nix"
+
 warnIfOutdated :: IO ()
 warnIfOutdated = do
     tryAny (BL8.readFile pathNixSourcesNix) >>= \case
@@ -243,6 +247,9 @@ warnIfOutdated = do
 -- | Glue code between nix and sources.json
 initNixSourcesNixContent :: B.ByteString
 initNixSourcesNixContent = $(embedFile "nix/sources.nix")
+
+initNixSourcesLibNixContent :: B.ByteString
+initNixSourcesLibNixContent = $(embedFile "nix/sources.lib.nix")
 
 -- | Empty JSON map
 initNixSourcesJsonContent :: B.ByteString


### PR DESCRIPTION
Hello!  I wanted to use this to open up discussion about accessing HTTP resources which are gated behind some authentication.  Not really sure what the best approach is, but I've stubbed out a WIP prototype here.

My specific use-case is accessing resources in the form of `https://$TOKEN@host.tld/<version>.ext` where `$TOKEN` is a private value therefore should not be written into `sources.json`.

The approach here exposes a `Spec -> Spec` transformation where an absent `url` field expands the `url_template`, where the expansion considers the other fields of the Spec as well as a new `runtime.env` list of environment variable names to peek at.

See the following for example.

``` json
    "example": {
        "runtime": {
            "env": [
                "TOKEN"
            ]
        },
        "type": "tarball",
        "sha256": "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
        "version": "1.2.3",
        "url_template": "https://<env:TOKEN>@server.domain/<version>.tar.gz"
    }
```


I've got this current proof-of-concept working by manually updating `sources.json` but haven't fleshed out the rest of the story for the `niv` cli commands.  Before I do so, I'd like feedback on

1. Is this an feature you would like in `niv`?
2. Any concerns with the current approach that might be blockers?

Ultimately, I'd like to have something like the following workflow

``` shell
niv init
niv add example \
    --no-url \
    -t "https://<env:TOKEN@server.domain/<version>.tar.gz" \
    --version 1.2.3 \
    --runtime-env TOKEN
niv update example --version 2.0.0
```


# Implementation notes

I opted to expose the new functionality in a new `sources.lib.nix` which is then exposed as `nixpkgs.lib.niv` using an overlay in `mkPkgs` in `sources.nix`

If you elect to run the tests (`nix-build nix/sources.lib.nix -A tests`) you'll need to `export HELLO=world` (sadly this is brittle but sufficient for a proof-of-concept IMO)
