### PR TITLE
Replace NixOS/nixpkgs-channels with NixOS/nixpkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,13 @@ initialized with niv and nixpkgs:
 ``` json
 {
     "nixpkgs": {
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/109a28ab954a0ad129f7621d468f829981b8b96c.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/109a28ab954a0ad129f7621d468f829981b8b96c.tar.gz",
         "owner": "NixOS",
         "branch": "nixos-19.09",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
-        "repo": "nixpkgs-channels",
+        "repo": "nixpkgs",
         "sha256": "12wnxla7ld4cgpdndaipdh3j4zdalifk287ihxhnmrzrghjahs3q",
-        "description": "Nixpkgs/NixOS branches that track the Nixpkgs/NixOS channels",
+        "description": "Nix Packages collection",
         "rev": "109a28ab954a0ad129f7621d468f829981b8b96c"
     },
     "niv": {
@@ -237,7 +237,7 @@ Available commands:
 Examples:
 
   niv add stedolan/jq
-  niv add NixOS/nixpkgs-channels -n nixpkgs -b nixos-19.09
+  niv add NixOS/nixpkgs -n nixpkgs -b nixos-19.09
   niv add my-package -v alpha-0.1 -t http://example.com/archive/<version>.zip
 
 Usage: niv add PACKAGE [-n|--name NAME] ([-a|--attribute KEY=VAL] |

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Available options:
   --no-nixpkgs             Don't add a nixpkgs entry to sources.json.
   -b,--nixpkgs-branch ARG  The nixpkgs branch to use. (default: "release-19.09")
   --nixpkgs OWNER/REPO     Use a custom nixpkgs repository from
-                           GitHub. (default: NixOS/nixpkgs-channels)
+                           GitHub. (default: NixOS/nixpkgs)
   -h,--help                Show this help text
 ```
 

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -107,13 +107,13 @@ initialized with niv and nixpkgs:
 ``` json
 {
     "nixpkgs": {
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/109a28ab954a0ad129f7621d468f829981b8b96c.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/109a28ab954a0ad129f7621d468f829981b8b96c.tar.gz",
         "owner": "NixOS",
         "branch": "nixos-19.09",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
-        "repo": "nixpkgs-channels",
+        "repo": "nixpkgs",
         "sha256": "12wnxla7ld4cgpdndaipdh3j4zdalifk287ihxhnmrzrghjahs3q",
-        "description": "Nixpkgs/NixOS branches that track the Nixpkgs/NixOS channels",
+        "description": "Nix Packages collection",
         "rev": "109a28ab954a0ad129f7621d468f829981b8b96c"
     },
     "niv": {

--- a/examples/cpp-libosmium/nix/sources.json
+++ b/examples/cpp-libosmium/nix/sources.json
@@ -25,14 +25,14 @@
     },
     "nixpkgs": {
         "branch": "nixos-19.09",
-        "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
+        "description": "Nix Packages collection",
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
-        "repo": "nixpkgs-channels",
+        "repo": "nixpkgs",
         "rev": "d85e435b7bded2596d7b201bcd938c94d8a921c1",
         "sha256": "1msjm4kx1z73v444i1iybvmc7z0kfkbn9nzr21rn5yc4ql1jwf99",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/d85e435b7bded2596d7b201bcd938c94d8a921c1.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/d85e435b7bded2596d7b201bcd938c94d8a921c1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/src/Niv/Cli.hs
+++ b/src/Niv/Cli.hs
@@ -109,7 +109,7 @@ instance Show Nixpkgs where
 
 -- | The default nixpkgs
 defaultNixpkgsRepo, defaultNixpkgsUser :: T.Text
-defaultNixpkgsRepo = "nixpkgs-channels"
+defaultNixpkgsRepo = "nixpkgs"
 defaultNixpkgsUser = "NixOS"
 
 parseCmdInit :: Opts.ParserInfo (NIO ())
@@ -139,7 +139,7 @@ parseCmdInit = Opts.info (cmdInit <$> parseNixpkgs <**> Opts.helper) $ mconcat d
         Opts.showDefault <>
         Opts.help "Use a custom nixpkgs repository from GitHub." <>
         Opts.metavar "OWNER/REPO" <>
-        Opts.value (Nixpkgs "NixOS" "nixpkgs-channels")
+        Opts.value (Nixpkgs defaultNixpkgsUser defaultNixpkgsRepo)
       ))
     desc =
       [ Opts.fullDesc

--- a/src/Niv/GitHub/Cmd.hs
+++ b/src/Niv/GitHub/Cmd.hs
@@ -110,7 +110,7 @@ describeGitHub = mconcat
       "Examples:" Opts.<$$>
       "" Opts.<$$>
       "  niv add stedolan/jq" Opts.<$$>
-      "  niv add NixOS/nixpkgs-channels -n nixpkgs -b nixos-19.09" Opts.<$$>
+      "  niv add NixOS/nixpkgs -n nixpkgs -b nixos-19.09" Opts.<$$>
       "  niv add my-package -v alpha-0.1 -t http://example.com/archive/<version>.zip"
   ]
 


### PR DESCRIPTION
Fixes https://github.com/nmattia/niv/issues/168

This is a completely naive search-and-replace with some artisanal description updating sprinkled on top. nixpkgs mirrors all the way down to 18.09, so I _think_ this is sufficient(?)

I've run the tests via `repl > :main` -- is there anything else I should do to verify?