### PR TITLE
Allow custom nixpkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,10 +351,15 @@ Available options:
 #### Init
 
 ```
-Usage: niv init 
+Usage: niv init ([--no-nixpkgs] | [-b|--nixpkgs-branch ARG]
+                [--nixpkgs OWNER/REPO])
   Initialize a Nix project. Existing files won't be modified.
 
 Available options:
+  --no-nixpkgs             Don't add a nixpkgs entry to sources.json.
+  -b,--nixpkgs-branch ARG  The nixpkgs branch to use. (default: "release-19.09")
+  --nixpkgs OWNER/REPO     Use a custom nixpkgs repository from
+                           GitHub. (default: NixOS/nixpkgs-channels)
   -h,--help                Show this help text
 ```
 

--- a/tests/github/default.nix
+++ b/tests/github/default.nix
@@ -76,7 +76,7 @@ pkgs.runCommand "test"
     cp ${./data/archives + "/${nixpkgs-channels_HEAD}.tar.gz"} \
       mock/NixOS/nixpkgs-channels/archive/${nixpkgs-channels_HEAD}.tar.gz
 
-    niv init
+    niv init --nixpkgs NixOS/nixpkgs-channels --nixpkgs-branch nixos-19.09
     diff -h ${./expected/niv-init.json} nix/sources.json || \
       (echo "Mismatched sources.json"; \
       echo "Reference: tests/expected/niv-init.json"; \


### PR DESCRIPTION
This adds a few configuration options to `niv init`:

* `--no-nixpkgs`: skips the import of nixpkgs
* `--nixpkgs-branch`: specifies the branch to use for nixpkgs
* `--nixpkgs`: specifies the repo to use for nixpkgs