### PR TITLE
Move to nixpkgs 20.03

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Available commands:
 Examples:
 
   niv add stedolan/jq
-  niv add NixOS/nixpkgs -n nixpkgs -b nixos-19.09
+  niv add NixOS/nixpkgs -n nixpkgs -b nixpkgs-unstable
   niv add my-package -v alpha-0.1 -t http://example.com/archive/<version>.zip
 
 Usage: niv add PACKAGE [-n|--name NAME] ([-a|--attribute KEY=VAL] |

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Usage: niv init ([--no-nixpkgs] | [-b|--nixpkgs-branch ARG]
 
 Available options:
   --no-nixpkgs             Don't add a nixpkgs entry to sources.json.
-  -b,--nixpkgs-branch ARG  The nixpkgs branch to use. (default: "release-19.09")
+  -b,--nixpkgs-branch ARG  The nixpkgs branch to use. (default: "release-20.03")
   --nixpkgs OWNER/REPO     Use a custom nixpkgs repository from
                            GitHub. (default: NixOS/nixpkgs)
   -h,--help                Show this help text

--- a/src/Niv/Cli.hs
+++ b/src/Niv/Cli.hs
@@ -111,7 +111,7 @@ instance Show Nixpkgs where
 defaultNixpkgsRepo, defaultNixpkgsUser, defaultNixpkgsBranch :: T.Text
 defaultNixpkgsRepo = "nixpkgs"
 defaultNixpkgsUser = "NixOS"
-defaultNixpkgsBranch = "release-19.09"
+defaultNixpkgsBranch = "release-20.03"
 
 parseCmdInit :: Opts.ParserInfo (NIO ())
 parseCmdInit = Opts.info (cmdInit <$> parseNixpkgs <**> Opts.helper) $ mconcat desc

--- a/src/Niv/Cli.hs
+++ b/src/Niv/Cli.hs
@@ -108,9 +108,10 @@ instance Show Nixpkgs where
   show (Nixpkgs o r) = T.unpack o <> "/" <> T.unpack r
 
 -- | The default nixpkgs
-defaultNixpkgsRepo, defaultNixpkgsUser :: T.Text
+defaultNixpkgsRepo, defaultNixpkgsUser, defaultNixpkgsBranch :: T.Text
 defaultNixpkgsRepo = "nixpkgs"
 defaultNixpkgsUser = "NixOS"
+defaultNixpkgsBranch = "release-19.09"
 
 parseCmdInit :: Opts.ParserInfo (NIO ())
 parseCmdInit = Opts.info (cmdInit <$> parseNixpkgs <**> Opts.helper) $ mconcat desc
@@ -131,7 +132,7 @@ parseCmdInit = Opts.info (cmdInit <$> parseNixpkgs <**> Opts.helper) $ mconcat d
           Opts.short 'b' <>
           Opts.help "The nixpkgs branch to use." <>
           Opts.showDefault <>
-          Opts.value "release-19.09"
+          Opts.value defaultNixpkgsBranch
         )
       ) <*> Opts.option customNixpkgsReader
       (
@@ -167,7 +168,7 @@ cmdInit nixpkgs = do
         , ( pathNixSourcesJson fsj
           , \path -> do
               createFile path initNixSourcesJsonContent
-              -- Imports @niv@ and @nixpkgs@ (19.09)
+              -- Imports @niv@ and @nixpkgs@
               say "Importing 'niv' ..."
               cmdAdd (updateCmd githubCmd) (PackageName "niv")
                 (specToFreeAttrs $ PackageSpec $ HMS.fromList

--- a/src/Niv/Cli.hs
+++ b/src/Niv/Cli.hs
@@ -100,7 +100,7 @@ parsePackage = (,) <$> parsePackageName <*> (parsePackageSpec githubCmd)
 -- | Whether or not to fetch nixpkgs
 data FetchNixpkgs
   = NoNixpkgs
-  | YesNixpkgs T.Text Nixpkgs
+  | YesNixpkgs T.Text Nixpkgs -- branch, nixpkgs
 
 data Nixpkgs = Nixpkgs T.Text T.Text -- owner, repo
 

--- a/src/Niv/GitHub/Cmd.hs
+++ b/src/Niv/GitHub/Cmd.hs
@@ -110,7 +110,7 @@ describeGitHub = mconcat
       "Examples:" Opts.<$$>
       "" Opts.<$$>
       "  niv add stedolan/jq" Opts.<$$>
-      "  niv add NixOS/nixpkgs -n nixpkgs -b nixos-19.09" Opts.<$$>
+      "  niv add NixOS/nixpkgs -n nixpkgs -b nixpkgs-unstable" Opts.<$$>
       "  niv add my-package -v alpha-0.1 -t http://example.com/archive/<version>.zip"
   ]
 


### PR DESCRIPTION
The `niv` executable will now import `release-20.03` by default, as opposed to `release-19.09`. 

Fixes #233 