### PR TITLE
Add NIV_OVERRIDE_{...}

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,12 @@ Available options:
 
 ## Frequently Asked Questions
 
-### Can you use private GitHub repositories?
+* [Can I use private GitHub repositories?](#can-i-use-private-github-repositories)
+* [How do I import a subpath of a source?](#how-do-i-import-a-subpath-of-a-source)
+* [How do I import NixOS modules](#how-do-i-import-nixos-modules)
+* [Can I use local packages?](#can-i-use-local-packages)
+
+### Can I use private GitHub repositories?
 
 Yes. There are two ways:
 
@@ -431,7 +436,7 @@ in sources.my-package + "/dir"
 in this example, `sources.my-package` becomes `my-package`'s root directory, and `+ "/dir"` appends the
 subdirectory.
 
-### How can I import NixOS modules?
+### How do I import NixOS modules?
 
 After the package containing the modules has been `niv add`ed, importing the
 modules is straightforward:
@@ -443,3 +448,17 @@ in {
   imports = [ (sources.package + "/path/to/module") ];
 }
 ```
+
+### Can I use local packages?
+
+If you need to use a local path as a source -- especially convenient when
+modifying dependencies -- `niv` allows you to override the `sources.json` via
+environment variables. To override a source `foo` with a local path
+`./bar/baz`, set the environment variable `NIV_OVERRIDE_foo` to `./bar/baz`.
+
+Generally, if the environment variable `NIV_OVERRIDE_<name>` is set _and_ you
+have a source named `<name>` then `niv` will use the value of
+`NIV_OVERRIDE_<name>` as the `outPath` of that source. All non-alphanumeric
+characters in the source name are escaped to the character `_`; i.e. to
+override the package `my package-foo` you need to set the environment variable
+`NIV_OVERRIDE_my_package_foo`.

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -260,7 +260,12 @@ replace_niv_show_help
 
 ## Frequently Asked Questions
 
-### Can you use private GitHub repositories?
+* [Can I use private GitHub repositories?](#can-i-use-private-github-repositories)
+* [How do I import a subpath of a source?](#how-do-i-import-a-subpath-of-a-source)
+* [How do I import NixOS modules](#how-do-i-import-nixos-modules)
+* [Can I use local packages?](#can-i-use-local-packages)
+
+### Can I use private GitHub repositories?
 
 Yes. There are two ways:
 
@@ -308,7 +313,7 @@ in sources.my-package + "/dir"
 in this example, `sources.my-package` becomes `my-package`'s root directory, and `+ "/dir"` appends the
 subdirectory.
 
-### How can I import NixOS modules?
+### How do I import NixOS modules?
 
 After the package containing the modules has been `niv add`ed, importing the
 modules is straightforward:
@@ -320,3 +325,17 @@ in {
   imports = [ (sources.package + "/path/to/module") ];
 }
 ```
+
+### Can I use local packages?
+
+If you need to use a local path as a source -- especially convenient when
+modifying dependencies -- `niv` allows you to override the `sources.json` via
+environment variables. To override a source `foo` with a local path
+`./bar/baz`, set the environment variable `NIV_OVERRIDE_foo` to `./bar/baz`.
+
+Generally, if the environment variable `NIV_OVERRIDE_<name>` is set _and_ you
+have a source named `<name>` then `niv` will use the value of
+`NIV_OVERRIDE_<name>` as the `outPath` of that source. All non-alphanumeric
+characters in the source name are escaped to the character `_`; i.e. to
+override the package `my package-foo` you need to set the environment variable
+`NIV_OVERRIDE_my_package_foo`.

--- a/default.nix
+++ b/default.nix
@@ -197,6 +197,7 @@ rec
 
   tests-github = pkgs.callPackage ./tests/github { inherit niv; };
   tests-git = pkgs.callPackage ./tests/git { inherit niv; };
+  tests-eval = pkgs.callPackage ./tests/eval {};
 
   fmt-check =
     pkgs.stdenv.mkDerivation

--- a/src/Niv/Sources.hs
+++ b/src/Niv/Sources.hs
@@ -160,6 +160,8 @@ data SourcesNixVersion
   | -- prettify derivation name
     -- add 'local' type of sources
     V18
+  | -- add NIV_OVERRIDE_{name}
+    V19
   deriving stock (Bounded, Enum, Eq)
 
 -- | A user friendly version
@@ -183,6 +185,7 @@ sourcesVersionToText = \case
   V16 -> "16"
   V17 -> "17"
   V18 -> "18"
+  V19 -> "19"
 
 latestVersionMD5 :: T.Text
 latestVersionMD5 = sourcesVersionToMD5 maxBound
@@ -213,6 +216,7 @@ sourcesVersionToMD5 = \case
   V16 -> "2d93c52cab8e960e767a79af05ca572a"
   V17 -> "149b8907f7b08dc1c28164dfa55c7fad"
   V18 -> "bc5e6aefcaa6f9e0b2155ca4f44e5a33"
+  V19 -> "543621698065cfc6a4a7985af76df718"
 
 -- | The MD5 sum of ./nix/sources.nix
 sourcesNixMD5 :: IO T.Text

--- a/tests/eval/default.nix
+++ b/tests/eval/default.nix
@@ -1,0 +1,45 @@
+{ pkgs ? import <nixpkgs> {}
+}:
+
+pkgs.runCommand "foobar" { nativeBuildInputs = [ pkgs.jq pkgs.nix pkgs.moreutils ]; }
+  ''
+    # for nix to run smoothly in multi-user install
+    # https://github.com/NixOS/nix/issues/3258
+    # https://github.com/cachix/install-nix-action/issues/16
+    export NIX_STATE_DIR="$TMPDIR"
+    export NIX_LOG_DIR="$TMPDIR"
+
+    cp ${ ../../nix/sources.nix} sources.nix
+    echo '{}' > sources.json
+
+    update_sources() {
+      cat sources.json | jq -cMe "$1" | sponge sources.json
+    }
+
+    update_sources '.foo = { type: "tarball", url: "foo", sha256: "whocares" }'
+    update_sources '."ba-r" = { type: "tarball", url: "foo", sha256: "whocares" }'
+    update_sources '."ba z" = { type: "tarball", url: "foo", sha256: "whocares" }'
+
+    eval_outPath() {
+      nix eval --raw '(let sources = import ./sources.nix; in sources.'"$1"'.outPath)'
+    }
+
+    eq() {
+      if ! [ "$1" == "$2" ]; then
+        echo "expected"
+        echo "  '$1' == '$2'"
+        exit 1
+      fi
+    }
+
+    res="$(NIV_OVERRIDE_foo="hello" eval_outPath "foo")"
+    eq "$res" "hello"
+
+    res="$(NIV_OVERRIDE_ba_r="hello" eval_outPath "ba-r")"
+    eq "$res" "hello"
+
+    res="$(NIV_OVERRIDE_ba_z="hello" eval_outPath '"ba z"')"
+    eq "$res" "hello"
+
+    touch "$out"
+  ''


### PR DESCRIPTION
This updates the sources.nix to replace the `outPath` field of package
`foo` with the content of envionment variable `NIV_OVERRIDE_foo`. In the
environment variable name, all characters outside of `[a-zA-Z0-9_]` are
escaped to `_`.