### PR TITLE
Make sources.nix remote friendly

### DIFF
--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -133,8 +133,8 @@ let
 
   # The "config" used by the fetchers
   mkConfig =
-    { sourcesFile ? ./sources.json
-    , sources ? builtins.fromJSON (builtins.readFile sourcesFile)
+    { sourcesFile ? if builtins.pathExists ./sources.json then ./sources.json else null
+    , sources ? if isNull sourcesFile then {} else builtins.fromJSON (builtins.readFile sourcesFile)
     , pkgs ? mkPkgs sources
     }: rec {
       # The sources, i.e. the attribute set of spec name to spec

--- a/src/Niv/Sources.hs
+++ b/src/Niv/Sources.hs
@@ -162,6 +162,8 @@ data SourcesNixVersion
     V18
   | -- add NIV_OVERRIDE_{name}
     V19
+  | -- can be imported when there's no sources.json
+    V20
   deriving stock (Bounded, Enum, Eq)
 
 -- | A user friendly version
@@ -186,6 +188,7 @@ sourcesVersionToText = \case
   V17 -> "17"
   V18 -> "18"
   V19 -> "19"
+  V20 -> "20"
 
 latestVersionMD5 :: T.Text
 latestVersionMD5 = sourcesVersionToMD5 maxBound
@@ -217,6 +220,7 @@ sourcesVersionToMD5 = \case
   V17 -> "149b8907f7b08dc1c28164dfa55c7fad"
   V18 -> "bc5e6aefcaa6f9e0b2155ca4f44e5a33"
   V19 -> "543621698065cfc6a4a7985af76df718"
+  V20 -> "ab4263aa63ccf44b4e1510149ce14eff"
 
 -- | The MD5 sum of ./nix/sources.nix
 sourcesNixMD5 :: IO T.Text

--- a/tests/eval/default.nix
+++ b/tests/eval/default.nix
@@ -41,5 +41,17 @@ pkgs.runCommand "foobar" { nativeBuildInputs = [ pkgs.jq pkgs.nix pkgs.moreutils
     res="$(NIV_OVERRIDE_ba_z="hello" eval_outPath '"ba z"')"
     eq "$res" "hello"
 
+    mkdir other
+    mv sources.json other
+
+    # Here we test that sources.nix can be imported even if there is no
+    # sources.json in the same directory
+    eval_outPath() {
+      nix eval --raw '(let sources = import ./sources.nix { sourcesFile = ./other/sources.json; } ; in sources.'"$1"'.outPath)'
+    }
+
+    res="$(NIV_OVERRIDE_foo="hello" eval_outPath "foo")"
+    eq "$res" "hello"
+
     touch "$out"
   ''


### PR DESCRIPTION
The file can now be imported even if there is no sources.json in the
same directory.