### PR TITLE
Sanitize source name

### DIFF
--- a/src/Niv/Sources.hs
+++ b/src/Niv/Sources.hs
@@ -224,7 +224,7 @@ sourcesVersionToMD5 = \case
   V18 -> "bc5e6aefcaa6f9e0b2155ca4f44e5a33"
   V19 -> "543621698065cfc6a4a7985af76df718"
   V20 -> "ab4263aa63ccf44b4e1510149ce14eff"
-  V21 -> "0b888c92e69629dd954f485bfb4a58ed"
+  V21 -> "c501eee378828f7f49828a140dbdbca3"
 
 -- | The MD5 sum of ./nix/sources.nix
 sourcesNixMD5 :: IO T.Text

--- a/src/Niv/Sources.hs
+++ b/src/Niv/Sources.hs
@@ -164,6 +164,8 @@ data SourcesNixVersion
     V19
   | -- can be imported when there's no sources.json
     V20
+  | -- Use the source name in fetchurl
+    V21
   deriving stock (Bounded, Enum, Eq)
 
 -- | A user friendly version
@@ -189,6 +191,7 @@ sourcesVersionToText = \case
   V18 -> "18"
   V19 -> "19"
   V20 -> "20"
+  V21 -> "21"
 
 latestVersionMD5 :: T.Text
 latestVersionMD5 = sourcesVersionToMD5 maxBound
@@ -221,6 +224,7 @@ sourcesVersionToMD5 = \case
   V18 -> "bc5e6aefcaa6f9e0b2155ca4f44e5a33"
   V19 -> "543621698065cfc6a4a7985af76df718"
   V20 -> "ab4263aa63ccf44b4e1510149ce14eff"
+  V21 -> "0b888c92e69629dd954f485bfb4a58ed"
 
 -- | The MD5 sum of ./nix/sources.nix
 sourcesNixMD5 :: IO T.Text

--- a/tests/eval/default.nix
+++ b/tests/eval/default.nix
@@ -1,45 +1,63 @@
 { pkgs ? import <nixpkgs> {}
 }:
 
-pkgs.runCommand "foobar" { nativeBuildInputs = [ pkgs.jq pkgs.nix pkgs.moreutils ]; }
+
+let
+  mkTest = name: text:
+    {
+      ${name} =
+        pkgs.runCommand name { nativeBuildInputs = [ pkgs.jq pkgs.nix pkgs.moreutils ]; }
+          ''
+            # for nix to run smoothly in multi-user install
+            # https://github.com/NixOS/nix/issues/3258
+            # https://github.com/cachix/install-nix-action/issues/16
+            export NIX_STATE_DIR="$TMPDIR"
+            export NIX_LOG_DIR="$TMPDIR"
+
+            cp ${ ../../nix/sources.nix} sources.nix
+            echo '{}' > sources.json
+
+            update_sources() {
+              cat sources.json | jq -cMe "$@" | sponge sources.json
+            }
+
+            eval_outPath() {
+              nix eval --raw '(let sources = import ./sources.nix; in sources.'"$1"'.outPath)'
+            }
+
+            eq() {
+              if ! [ "$1" == "$2" ]; then
+                echo "expected"
+                echo "  '$1' == '$2'"
+                exit 1
+              fi
+            }
+
+            ${text}
+
+            touch "$out"
+          '';
+    };
+in
+
+mkTest "simple-eval" ''
+
+        update_sources '.foo = { type: "tarball", url: "foo", sha256: "whocares" }'
+        update_sources '."ba-r" = { type: "tarball", url: "foo", sha256: "whocares" }'
+        update_sources '."ba z" = { type: "tarball", url: "foo", sha256: "whocares" }'
+
+        res="$(NIV_OVERRIDE_foo="hello" eval_outPath "foo")"
+        eq "$res" "hello"
+
+        res="$(NIV_OVERRIDE_ba_r="hello" eval_outPath "ba-r")"
+        eq "$res" "hello"
+
+        res="$(NIV_OVERRIDE_ba_z="hello" eval_outPath '"ba z"')"
+        eq "$res" "hello"
+
+  '' // mkTest "sources-json-elsewhere"
   ''
-    # for nix to run smoothly in multi-user install
-    # https://github.com/NixOS/nix/issues/3258
-    # https://github.com/cachix/install-nix-action/issues/16
-    export NIX_STATE_DIR="$TMPDIR"
-    export NIX_LOG_DIR="$TMPDIR"
-
-    cp ${ ../../nix/sources.nix} sources.nix
-    echo '{}' > sources.json
-
-    update_sources() {
-      cat sources.json | jq -cMe "$1" | sponge sources.json
-    }
-
     update_sources '.foo = { type: "tarball", url: "foo", sha256: "whocares" }'
-    update_sources '."ba-r" = { type: "tarball", url: "foo", sha256: "whocares" }'
-    update_sources '."ba z" = { type: "tarball", url: "foo", sha256: "whocares" }'
-
-    eval_outPath() {
-      nix eval --raw '(let sources = import ./sources.nix; in sources.'"$1"'.outPath)'
-    }
-
-    eq() {
-      if ! [ "$1" == "$2" ]; then
-        echo "expected"
-        echo "  '$1' == '$2'"
-        exit 1
-      fi
-    }
-
-    res="$(NIV_OVERRIDE_foo="hello" eval_outPath "foo")"
-    eq "$res" "hello"
-
-    res="$(NIV_OVERRIDE_ba_r="hello" eval_outPath "ba-r")"
-    eq "$res" "hello"
-
-    res="$(NIV_OVERRIDE_ba_z="hello" eval_outPath '"ba z"')"
-    eq "$res" "hello"
 
     mkdir other
     mv sources.json other
@@ -52,6 +70,4 @@ pkgs.runCommand "foobar" { nativeBuildInputs = [ pkgs.jq pkgs.nix pkgs.moreutils
 
     res="$(NIV_OVERRIDE_foo="hello" eval_outPath "foo")"
     eq "$res" "hello"
-
-    touch "$out"
   ''

--- a/tests/eval/default.nix
+++ b/tests/eval/default.nix
@@ -40,7 +40,7 @@ let
     };
 in
 
-mkTest "simple-eval" ''
+mkTest "niv-override-eval" ''
 
         update_sources '.foo = { type: "tarball", url: "foo", sha256: "whocares" }'
         update_sources '."ba-r" = { type: "tarball", url: "foo", sha256: "whocares" }'
@@ -70,4 +70,17 @@ mkTest "simple-eval" ''
 
     res="$(NIV_OVERRIDE_foo="hello" eval_outPath "foo")"
     eq "$res" "hello"
+  ''
+
+// mkTest "sanitize-source-name"
+  ''
+    file=$(mktemp -d)/foo%%.bar
+    touch "$file"
+    sha=$(nix-hash --type sha256 --flat $file)
+    url="file://$file"
+
+    update_sources '.foo = { type: "file", url: $url, sha256: $sha}' --arg url "$url" --arg sha "$sha"
+
+    # we don't need to check the result, we just make sure this evaluates
+    eval_outPath "foo"
   ''


### PR DESCRIPTION
The `file` sources didn't get a name, and didn't get their name sanitized. This also fixes a
bug where builtins_fetchTarball would fail if because no name was given.

Fixes #264 
Fixes #262 