### PR TITLE
Stop using ref in builtins.fetchGit fetcher

### DIFF
--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -24,8 +24,15 @@ let
       else
         pkgs.fetchzip { name = name'; inherit (spec) url sha256; };
 
-  fetch_git = spec:
-    builtins.fetchGit { url = spec.repo; inherit (spec) rev ref; };
+  fetch_git = name: spec:
+    let
+      ref =
+        if spec ? ref then spec.ref else
+          if spec ? branch then "refs/heads/${spec.branch}" else
+            if spec ? tag then "refs/tags/${spec.tag}" else
+              abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
+    in
+      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; };
 
   fetch_local = spec: spec.path;
 
@@ -77,7 +84,7 @@ let
       abort "ERROR: niv spec ${name} does not have a 'type' attribute"
     else if spec.type == "file" then fetch_file pkgs name spec
     else if spec.type == "tarball" then fetch_tarball pkgs name spec
-    else if spec.type == "git" then fetch_git spec
+    else if spec.type == "git" then fetch_git name spec
     else if spec.type == "local" then fetch_local spec
     else if spec.type == "builtin-tarball" then fetch_builtin-tarball name
     else if spec.type == "builtin-url" then fetch_builtin-url name

--- a/src/Niv/Cmd.hs
+++ b/src/Niv/Cmd.hs
@@ -15,5 +15,7 @@ data Cmd
         parseCmdShortcut :: T.Text -> Maybe (PackageName, Aeson.Object),
         parsePackageSpec :: Opts.Parser PackageSpec,
         updateCmd :: Update () (),
-        name :: T.Text
+        name :: T.Text,
+        -- | Some notes to print
+        extraLogs :: Attrs -> [T.Text]
       }

--- a/src/Niv/Git/Test.hs
+++ b/src/Niv/Git/Test.hs
@@ -57,7 +57,7 @@ test_gitUpdates =
 test_gitUpdateRev :: IO ()
 test_gitUpdateRev = do
   interState <- evalUpdate initialState $ proc () ->
-    gitUpdate (error "should be def") defaultRefAndHEAD' -< ()
+    gitUpdate (error "should be def") defaultBranchAndHEAD' -< ()
   let interState' = HMS.map (first (\_ -> Free)) interState
   actualState <- evalUpdate interState' $ proc () ->
     gitUpdate latestRev' (error "should update") -< ()
@@ -66,14 +66,14 @@ test_gitUpdateRev = do
     $ "State mismatch: " <> show actualState
   where
     latestRev' _ _ = pure "some-other-rev"
-    defaultRefAndHEAD' _ = pure ("some-ref", "some-rev")
+    defaultBranchAndHEAD' _ = pure ("some-branch", "some-rev")
     initialState =
       HMS.fromList
         [("repo", (Free, "git@github.com:nmattia/niv"))]
     expectedState =
       HMS.fromList
         [ ("repo", "git@github.com:nmattia/niv"),
-          ("ref", "some-ref"),
+          ("branch", "some-branch"),
           ("rev", "some-other-rev"),
           ("type", "git")
         ]
@@ -104,10 +104,10 @@ once2 f = do
 -- the update
 test_gitCalledOnce :: IO ()
 test_gitCalledOnce = do
-  defaultRefAndHEAD'' <- once1 defaultRefAndHEAD'
+  defaultBranchAndHEAD'' <- once1 defaultBranchAndHEAD'
   latestRev'' <- once2 latestRev'
   interState <- evalUpdate initialState $ proc () ->
-    gitUpdate (error "should be def") defaultRefAndHEAD'' -< ()
+    gitUpdate (error "should be def") defaultBranchAndHEAD'' -< ()
   let interState' = HMS.map (first (\_ -> Free)) interState
   actualState <- evalUpdate interState' $ proc () ->
     gitUpdate latestRev'' (error "should update") -< ()
@@ -116,14 +116,14 @@ test_gitCalledOnce = do
     $ "State mismatch: " <> show actualState
   where
     latestRev' _ _ = pure "some-other-rev"
-    defaultRefAndHEAD' _ = pure ("some-ref", "some-rev")
+    defaultBranchAndHEAD' _ = pure ("some-branch", "some-rev")
     initialState =
       HMS.fromList
         [("repo", (Free, "git@github.com:nmattia/niv"))]
     expectedState =
       HMS.fromList
         [ ("repo", "git@github.com:nmattia/niv"),
-          ("ref", "some-ref"),
+          ("branch", "some-branch"),
           ("rev", "some-other-rev"),
           ("type", "git")
         ]

--- a/src/Niv/GitHub/Cmd.hs
+++ b/src/Niv/GitHub/Cmd.hs
@@ -38,7 +38,8 @@ githubCmd =
       parseCmdShortcut = parseAddShortcutGitHub,
       parsePackageSpec = parseGitHubPackageSpec,
       updateCmd = githubUpdate',
-      name = "github"
+      name = "github",
+      extraLogs = const []
       -- TODO: here filter by type == tarball or file or builtin-
     }
 

--- a/src/Niv/Local/Cmd.hs
+++ b/src/Niv/Local/Cmd.hs
@@ -27,7 +27,8 @@ localCmd =
       updateCmd = proc () -> do
         useOrSet "type" -< ("local" :: Box T.Text)
         returnA -< (),
-      name = "local"
+      name = "local",
+      extraLogs = const []
     }
 
 parseLocalShortcut :: T.Text -> Maybe (PackageName, Aeson.Object)

--- a/src/Niv/Logger.hs
+++ b/src/Niv/Logger.hs
@@ -8,6 +8,9 @@ module Niv.Logger
     bug,
     tsay,
     say,
+    twarn,
+    mkWarn,
+    mkNote,
     green,
     tgreen,
     red,
@@ -72,6 +75,15 @@ say msg = do
   -- we use `intercalate "\n"` because `unlines` prints an extra newline at
   -- the end
   liftIO $ putStrLn $ intercalate "\n" $ (indent <>) <$> lines msg
+
+mkWarn :: T.Text -> T.Text
+mkWarn w = tbold (tyellow "WARNING") <> ": " <> w
+
+twarn :: MonadIO io => T.Text -> io ()
+twarn = tsay . mkWarn
+
+mkNote :: T.Text -> T.Text
+mkNote w = tbold (tblue "NOTE") <> ": " <> w
 
 green :: S
 green str =

--- a/src/Niv/Sources.hs
+++ b/src/Niv/Sources.hs
@@ -166,6 +166,8 @@ data SourcesNixVersion
     V20
   | -- Use the source name in fetchurl
     V21
+  | -- Stop setting `ref` and use `branch` and `tag` in sources
+    V22
   deriving stock (Bounded, Enum, Eq)
 
 -- | A user friendly version
@@ -192,6 +194,7 @@ sourcesVersionToText = \case
   V19 -> "19"
   V20 -> "20"
   V21 -> "21"
+  V22 -> "22"
 
 latestVersionMD5 :: T.Text
 latestVersionMD5 = sourcesVersionToMD5 maxBound
@@ -225,6 +228,7 @@ sourcesVersionToMD5 = \case
   V19 -> "543621698065cfc6a4a7985af76df718"
   V20 -> "ab4263aa63ccf44b4e1510149ce14eff"
   V21 -> "c501eee378828f7f49828a140dbdbca3"
+  V22 -> "935d1d2f0bf95fda977a6e3a7e548ed4"
 
 -- | The MD5 sum of ./nix/sources.nix
 sourcesNixMD5 :: IO T.Text

--- a/src/Niv/Sources.hs
+++ b/src/Niv/Sources.hs
@@ -242,9 +242,9 @@ warnIfOutdated :: IO ()
 warnIfOutdated = do
   tryAny (BL8.readFile pathNixSourcesNix) >>= \case
     Left e ->
-      tsay $
-        T.unlines -- warn with tsay
-          [ T.unwords [tyellow "WARNING:", "Could not read", T.pack pathNixSourcesNix],
+      twarn $
+        T.unlines
+          [ T.unwords ["Could not read", T.pack pathNixSourcesNix],
             T.unwords ["  ", "(", tshow e, ")"]
           ]
     Right content -> do

--- a/tests/git/default.nix
+++ b/tests/git/default.nix
@@ -63,7 +63,7 @@ pkgs.runCommand "git-test"
         exit 42
       fi
 
-      niv update my-git-repo -a ref=branch
+      niv update my-git-repo -b branch
       nivrev2=$(nix eval --json '(import ./nix/sources.nix).my-git-repo.rev' | jq -r)
       if [ ! "$gitrev2" = "$nivrev2" ]; then
         echo "Mismatched revs: $gitrev2 != $nivrev2"


### PR DESCRIPTION
Instead, sources now record either `branch` or `tag`. The fetcher
specifies the correct ref (`/refs/heads/...` or `/refs/tags/...`) which
works in the newest version of Nix. The `ref` attribute can still be set
to override the logic.

Fixes #266 