### PR TITLE
sources.nix: bootstrap with a custom system

### DIFF
--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -59,10 +59,10 @@ let
     );
 
   # The set of packages used when specs are fetched using non-builtins.
-  mkPkgs = sources:
+  mkPkgs = sources: system:
     let
       sourcesNixpkgs =
-        import (builtins_fetchTarball { inherit (sources.nixpkgs) url sha256; }) {};
+        import (builtins_fetchTarball { inherit (sources.nixpkgs) url sha256; }) { inherit system; };
       hasNixpkgsPath = builtins.any (x: x.prefix == "nixpkgs") builtins.nixPath;
       hasThisAsNixpkgsPath = <nixpkgs> == ./.;
     in
@@ -157,7 +157,8 @@ let
   mkConfig =
     { sourcesFile ? if builtins.pathExists ./sources.json then ./sources.json else null
     , sources ? if isNull sourcesFile then {} else builtins.fromJSON (builtins.readFile sourcesFile)
-    , pkgs ? mkPkgs sources
+    , system ? builtins.currentSystem
+    , pkgs ? mkPkgs sources system
     }: rec {
       # The sources, i.e. the attribute set of spec name to spec
       inherit sources;

--- a/src/Niv/Sources.hs
+++ b/src/Niv/Sources.hs
@@ -168,6 +168,8 @@ data SourcesNixVersion
     V21
   | -- Stop setting `ref` and use `branch` and `tag` in sources
     V22
+  | -- Allow to pass custom system to bootstrap niv in pure mode
+    V23
   deriving stock (Bounded, Enum, Eq)
 
 -- | A user friendly version
@@ -195,6 +197,7 @@ sourcesVersionToText = \case
   V20 -> "20"
   V21 -> "21"
   V22 -> "22"
+  V23 -> "23"
 
 latestVersionMD5 :: T.Text
 latestVersionMD5 = sourcesVersionToMD5 maxBound
@@ -229,6 +232,7 @@ sourcesVersionToMD5 = \case
   V20 -> "ab4263aa63ccf44b4e1510149ce14eff"
   V21 -> "c501eee378828f7f49828a140dbdbca3"
   V22 -> "935d1d2f0bf95fda977a6e3a7e548ed4"
+  V23 -> "4111204b613ec688e2669516dd313440"
 
 -- | The MD5 sum of ./nix/sources.nix
 sourcesNixMD5 :: IO T.Text


### PR DESCRIPTION
When combining Nix Flakes with niv, `builtins.currentSystem` is
disabled. This allows to bootstrap nixpkgs by passing the system from
the flake evaluation.