### PR TITLE
Prepend environment variables with NIV_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## UNRELEASED
+## Changed
+* `GITHUB_PATH` was renamed to `NIV_GITHUB_PATH` https://github.com/nmattia/niv/issues/280
+* `GITHUB_INSECURE` was renamed to `NIV_GITHUB_INSECURE` https://github.com/nmattia/niv/issues/280
+
 ## [0.2.17] 2020-09-08
 ## Added
 * There is a new flag `-r/--rev` for specifying a revision during update and add

--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ The following environment variables are read by `niv`:
 
 | Name            | Note |
 | --------------- | ---- |
-| GITHUB_TOKEN    | When set, the value is used to authenticate GitHub API requests. |
-| GITHUB_HOST     | The GitHub host to use when fetching packages. Port may be appended here. |
-| GITHUB_API_HOST | The host used when performing GitHub API requests. Use `GITHUB_API_PORT` for specifying the port. |
-| GITHUB_API_PORT | The port used when performing GitHub API requests. Defaults to `443` for secure requests. Defaults to `80` for insecure requests. See also: `GITHUB_INSECURE`. |
-| GITHUB_INSECURE | When set to anything but the empty string, requests are performed over `http` instead of `https`. |
-| GITHUB_PATH     | The base path used when performing GitHub API requests. |
+| GITHUB_TOKEN or NIV_GITHUB_TOKEN | When set, the value is used to authenticate GitHub API requests. |
+| GITHUB_HOST or NIV_GITHUB_HOST | The GitHub host to use when fetching packages. Port may be appended here. |
+| GITHUB_API_HOST or NIV_GITHUB_API_HOST | The host used when performing GitHub API requests. Use `GITHUB_API_PORT` for specifying the port. |
+| GITHUB_API_PORT or NIV_GITHUB_API_PORT | The port used when performing GitHub API requests. Defaults to `443` for secure requests. Defaults to `80` for insecure requests. See also: `GITHUB_INSECURE`. |
+| NIV_GITHUB_INSECURE | When set to anything but the empty string, requests are performed over `http` instead of `https`. |
+| NIV_GITHUB_PATH     | The base path used when performing GitHub API requests. |
 
 The next two sections cover [common use cases](#getting-started) and [full command
 description](#commands).

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -69,12 +69,12 @@ The following environment variables are read by `niv`:
 
 | Name            | Note |
 | --------------- | ---- |
-| GITHUB_TOKEN    | When set, the value is used to authenticate GitHub API requests. |
-| GITHUB_HOST     | The GitHub host to use when fetching packages. Port may be appended here. |
-| GITHUB_API_HOST | The host used when performing GitHub API requests. Use `GITHUB_API_PORT` for specifying the port. |
-| GITHUB_API_PORT | The port used when performing GitHub API requests. Defaults to `443` for secure requests. Defaults to `80` for insecure requests. See also: `GITHUB_INSECURE`. |
-| GITHUB_INSECURE | When set to anything but the empty string, requests are performed over `http` instead of `https`. |
-| GITHUB_PATH     | The base path used when performing GitHub API requests. |
+| GITHUB_TOKEN or NIV_GITHUB_TOKEN | When set, the value is used to authenticate GitHub API requests. |
+| GITHUB_HOST or NIV_GITHUB_HOST | The GitHub host to use when fetching packages. Port may be appended here. |
+| GITHUB_API_HOST or NIV_GITHUB_API_HOST | The host used when performing GitHub API requests. Use `GITHUB_API_PORT` for specifying the port. |
+| GITHUB_API_PORT or NIV_GITHUB_API_PORT | The port used when performing GitHub API requests. Defaults to `443` for secure requests. Defaults to `80` for insecure requests. See also: `GITHUB_INSECURE`. |
+| NIV_GITHUB_INSECURE | When set to anything but the empty string, requests are performed over `http` instead of `https`. |
+| NIV_GITHUB_PATH     | The base path used when performing GitHub API requests. |
 
 The next two sections cover [common use cases](#getting-started) and [full command
 description](#commands).

--- a/src/Niv/Cli.hs
+++ b/src/Niv/Cli.hs
@@ -24,6 +24,7 @@ import Data.Text.Extended
 import Data.Version (showVersion)
 import Niv.Cmd
 import Niv.Git.Cmd
+import Niv.GitHub.API (warnGitHubEnvVars)
 import Niv.GitHub.Cmd
 import Niv.Local.Cmd
 import Niv.Logger
@@ -52,6 +53,7 @@ li = liftIO
 
 cli :: IO ()
 cli = do
+  warnGitHubEnvVars
   (fsj, nio) <-
     execParserPure' Opts.defaultPrefs opts <$> getArgs
       >>= Opts.handleParseResult

--- a/tests/github/default.nix
+++ b/tests/github/default.nix
@@ -32,10 +32,10 @@ pkgs.runCommand "test"
   ''
     set -euo pipefail
 
-    export GITHUB_HOST="localhost:3333"
-    export GITHUB_API_HOST="localhost"
-    export GITHUB_API_PORT="3333"
-    export GITHUB_INSECURE="true"
+    export NIV_GITHUB_HOST="localhost:3333"
+    export NIV_GITHUB_API_HOST="localhost"
+    export NIV_GITHUB_API_PORT="3333"
+    export NIV_GITHUB_INSECURE="true"
 
     echo *** Starting the webserver...
     mkdir -p mock


### PR DESCRIPTION
Here we make sure that some environment variables are prepended
(GITHUB_PATH, GITHUB_INSECURE). For consistency's sake, other
environment variables (GITHUB_TOKEN, etc) _can_ also be prepended with
NIV_. This also issues a warning if `GITHUB_PATH` or `GITHUB_INSECURE`
is set.