### PR TITLE
Turn NIV_OVERRIDE values into paths

### DIFF
--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -98,7 +98,10 @@ let
       saneName = stringAsChars (c: if isNull (builtins.match "[a-zA-Z0-9]" c) then "_" else c) name;
       ersatz = builtins.getEnv "NIV_OVERRIDE_${saneName}";
     in
-      if ersatz == "" then drv else ersatz;
+      if ersatz == "" then drv else
+        # this turns the string into an actual Nix path (for both absolute and
+        # relative paths)
+        if builtins.substring 0 1 ersatz == "/" then /. + ersatz else /. + builtins.getEnv "PWD" + "/${ersatz}";
 
   # Ports of functions for older nix versions
 

--- a/src/Niv/Sources.hs
+++ b/src/Niv/Sources.hs
@@ -170,6 +170,8 @@ data SourcesNixVersion
     V22
   | -- Allow to pass custom system to bootstrap niv in pure mode
     V23
+  | -- Fix NIV_OVERRIDE_{name} for sandbox
+    V24
   deriving stock (Bounded, Enum, Eq)
 
 -- | A user friendly version
@@ -198,6 +200,7 @@ sourcesVersionToText = \case
   V21 -> "21"
   V22 -> "22"
   V23 -> "23"
+  V24 -> "24"
 
 latestVersionMD5 :: T.Text
 latestVersionMD5 = sourcesVersionToMD5 maxBound
@@ -233,6 +236,7 @@ sourcesVersionToMD5 = \case
   V21 -> "c501eee378828f7f49828a140dbdbca3"
   V22 -> "935d1d2f0bf95fda977a6e3a7e548ed4"
   V23 -> "4111204b613ec688e2669516dd313440"
+  V24 -> "116c2d936f1847112fef0013771dab28"
 
 -- | The MD5 sum of ./nix/sources.nix
 sourcesNixMD5 :: IO T.Text


### PR DESCRIPTION
Otherwise they're not accessible from the sandbox.