### PR TITLE
Respect type attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ## Changed
 * `GITHUB_PATH` was renamed to `NIV_GITHUB_PATH` https://github.com/nmattia/niv/issues/280
 * `GITHUB_INSECURE` was renamed to `NIV_GITHUB_INSECURE` https://github.com/nmattia/niv/issues/280
+* If `-T` is provided on the command line for `niv add` it will be respected and no guessing from the url is done.
+* `type` attribute is now respected.
+* If an url template is updated, `type` needs to be adjusted manuall as it is not guessed from the new url template.
 
 ## [0.2.17] 2020-09-08
 ## Added

--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ documentation for [add](#add) and [update](#update)).
 The type of the dependency is guessed from the provided URL template, if `-T`
 is not specified.
 
+For updating the version of GHC used run this command:
+
 ``` shell
 $ niv update ghc -v 8.6.2
 ```

--- a/README.md
+++ b/README.md
@@ -205,11 +205,14 @@ The option `-v` sets the "version" attribute to `8.4.3`. The option `-t` sets a
 template that can be reused by niv when fetching a new URL (see the
 documentation for [add](#add) and [update](#update)).
 
-For updating the version of GHC used run this command:
+The type of the dependency is guessed from the provided URL template, if `-T`
+is not specified.
 
 ``` shell
 $ niv update ghc -v 8.6.2
 ```
+
+The downloads 
 
 ### Commands
 

--- a/README.md
+++ b/README.md
@@ -212,8 +212,6 @@ is not specified.
 $ niv update ghc -v 8.6.2
 ```
 
-The downloads 
-
 ### Commands
 
 ```

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -205,6 +205,9 @@ The option `-v` sets the "version" attribute to `8.4.3`. The option `-t` sets a
 template that can be reused by niv when fetching a new URL (see the
 documentation for [add](#add) and [update](#update)).
 
+The type of the dependency is guessed from the provided URL template, if `-T`
+is not specified.
+
 For updating the version of GHC used run this command:
 
 ``` shell

--- a/src/Niv/GitHub.hs
+++ b/src/Niv/GitHub.hs
@@ -34,9 +34,9 @@ githubUpdate prefetch latestRev ghRepo = proc () -> do
       <<< (useOrSet "url_template" <<< completeSpec) <+> (load "url_template") -<
       ()
   url <- update "url" -< urlTemplate
-  let isTar = (\u -> "tar.gz" `T.isSuffixOf` u || ".tgz" `T.isSuffixOf` u) <$> url
-  useOrSet "type" -< bool "file" "tarball" <$> isTar :: Box T.Text
-  let doUnpack = isTar
+  let isTarGuess = (\u -> "tar.gz" `T.isSuffixOf` u || ".tgz" `T.isSuffixOf` u) <$> url
+  type' <- useOrSet "type" -< bool "file" "tarball" <$> isTarGuess :: Box T.Text
+  let doUnpack = (== "tarball") <$> type'
   _sha256 <- update "sha256" <<< run (\(up, u) -> prefetch up u) -< (,) <$> doUnpack <*> url
   returnA -< ()
   where


### PR DESCRIPTION
Only guess the type of the download, if `-T` is not specified.

Respect `-T` if it is provided.

Closes #289 

Would be the behaviour I would have expected naively.