### PR TITLE
Fix GitHub action to publish to cachix

### DIFF
--- a/.github/actions/nix/install-nix
+++ b/.github/actions/nix/install-nix
@@ -22,14 +22,14 @@ install_nix() {
 
       # macOS needs certificates hints
       cert_file=/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt
-      echo "::set-env name=NIX_SSL_CERT_FILE::$cert_file"
-      export NIX_SSL_CERT_FILE=$cert_file
+      echo "NIX_SSL_CERT_FILE=$cert_file" >>"$GITHUB_ENV"
+      export NIX_SSL_CERT_FILE="$cert_file"
       sudo launchctl setenv NIX_SSL_CERT_FILE "$cert_file"
     fi
 
     # Set paths
-    echo "::add-path::/nix/var/nix/profiles/per-user/runner/profile/bin"
-    echo "::add-path::/nix/var/nix/profiles/default/bin"
+    echo "/nix/var/nix/profiles/per-user/runner/profile/bin" >>"$GITHUB_PATH"
+    echo "/nix/var/nix/profiles/default/bin" >>"$GITHUB_PATH"
     . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
 }
 
@@ -80,5 +80,5 @@ if [ "${INSTALL_NIX_WAS_RUN:-}" == "1" ]; then
 else
     install_nix
     install_cachix
-    echo "::set-env name=INSTALL_NIX_WAS_RUN::1"
+    echo "INSTALL_NIX_WAS_RUN=1" >>"$GITHUB_ENV"
 fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-18.04, macos-10.15]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: './.github/actions/nix'
       with:
         CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}


### PR DESCRIPTION
GitHub has deprecated setting the environment variables and paths via
echoing to the stdout:

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Thus, this PR brings the code up to data with the recommendations in the
linked post. In short, paths are exposed to subsequent steps by
appending to the file named in `$GITHUB_PATH`, while environment
variables are set by appending `name=value` to the file named in
`$GITHUB_ENV`.