### PR TITLE
Slightly refactor renderTemplate to support newer GHCs

### DIFF
--- a/src/Niv/Update.hs
+++ b/src/Niv/Update.hs
@@ -286,17 +286,15 @@ decodeValue msg v = case Aeson.fromJSON v of
 --  renderTemplate ("foo" -> "bar") "<foo>" -> pure (Just "bar")
 --  renderTemplate ("foo" -> "bar") "<baz>" -> pure Nothing
 renderTemplate :: (T.Text -> Maybe (Box T.Text)) -> T.Text -> Maybe (Box T.Text)
-renderTemplate vals = \case
-  (T.uncons -> Just ('<', str)) -> do
+renderTemplate vals tpl = case T.uncons tpl of
+  Just ('<', str) -> do
     case T.span (/= '>') str of
       (key, T.uncons -> Just ('>', rest)) -> do
         let v = vals key
         (liftA2 (<>) v) (renderTemplate vals rest)
       _ -> Nothing
-  (T.uncons -> Just (c, str)) -> fmap (T.cons c) <$> renderTemplate vals str
-  (T.uncons -> Nothing) -> Just $ pure T.empty
-  -- XXX: isn't this redundant?
-  _ -> Just $ pure T.empty
+  Just (c, str) -> fmap (T.cons c) <$> renderTemplate vals str
+  Nothing -> Just $ pure T.empty
 
 template :: Update (Box T.Text) (Box T.Text)
 template = Template


### PR DESCRIPTION
This refactoring makes the package build with both the currently
supported GHC (8.6.5) and newer ones (notably 8.10, I haven't tried with
8.8).