### PR TITLE
Speed up initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,15 +364,19 @@ Available options:
 #### Init
 
 ```
-Usage: niv init [--no-nixpkgs | [-b|--nixpkgs-branch ARG] 
-                  [--nixpkgs OWNER/REPO]]
+Usage: niv init [--fast | --latest | --nixpkgs OWNER/REPO
+                  (-b|--nixpkgs-branch ARG) |
+                  --no-nixpkgs]
   Initialize a Nix project. Existing files won't be modified.
 
 Available options:
-  --no-nixpkgs             Don't add a nixpkgs entry to sources.json.
-  -b,--nixpkgs-branch ARG  The nixpkgs branch to use. (default: "release-20.03")
+  --fast                   Use the latest nixpkgs cached at
+                           'https://github.com/nmattia/niv/blob/master/data/nixpkgs.json'.
+                           This is the default.
+  --latest                 Pull the latest unstable nixpkgs from NixOS/nixpkgs.
   --nixpkgs OWNER/REPO     Use a custom nixpkgs repository from GitHub.
-                           (default: NixOS/nixpkgs)
+  -b,--nixpkgs-branch ARG  The nixpkgs branch when using --nixpkgs ....
+  --no-nixpkgs             Don't add a nixpkgs entry to sources.json.
   -h,--help                Show this help text
 ```
 

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,4 @@
+# Data
+
+`./nixpkgs.json` is the default value used by niv when initializing `nixpkgs`.
+The executable fetches the latest version from the repo.

--- a/data/nixpkgs.json
+++ b/data/nixpkgs.json
@@ -1,0 +1,12 @@
+{
+  "branch": "release-21.05",
+  "description": "Nix Packages collection",
+  "homepage": "",
+  "owner": "NixOS",
+  "repo": "nixpkgs",
+  "rev": "5f244caea76105b63d826911b2a1563d33ff1cdc",
+  "sha256": "1xlgynfw9svy7nvh9nkxsxdzncv9hg99gbvbwv3gmrhmzc3sar75",
+  "type": "tarball",
+  "url": "https://github.com/NixOS/nixpkgs/archive/5f244caea76105b63d826911b2a1563d33ff1cdc.tar.gz",
+  "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+}

--- a/src/Niv/Cli.hs
+++ b/src/Niv/Cli.hs
@@ -22,6 +22,7 @@ import Data.Hashable (Hashable)
 import qualified Data.Text as T
 import Data.Text.Extended
 import Data.Version (showVersion)
+import qualified Network.HTTP.Simple as HTTP
 import Niv.Cmd
 import Niv.Git.Cmd
 import Niv.GitHub.Cmd
@@ -118,54 +119,65 @@ parsePackage = (,) <$> parsePackageName <*> (parsePackageSpec githubCmd)
 -- | Whether or not to fetch nixpkgs
 data FetchNixpkgs
   = NoNixpkgs
-  | YesNixpkgs T.Text Nixpkgs -- branch, nixpkgs
+  | NixpkgsFast -- Pull latest known nixpkgs
+  | NixpkgsCustom T.Text Nixpkgs -- branch, nixpkgs
+  deriving (Show)
 
 data Nixpkgs = Nixpkgs T.Text T.Text -- owner, repo
 
 instance Show Nixpkgs where
   show (Nixpkgs o r) = T.unpack o <> "/" <> T.unpack r
 
--- | The default nixpkgs
-defaultNixpkgsRepo, defaultNixpkgsUser, defaultNixpkgsBranch :: T.Text
-defaultNixpkgsRepo = "nixpkgs"
-defaultNixpkgsUser = "NixOS"
-defaultNixpkgsBranch = "release-20.03"
-
 parseCmdInit :: Opts.ParserInfo (NIO ())
 parseCmdInit = Opts.info (cmdInit <$> parseNixpkgs <**> Opts.helper) $ mconcat desc
   where
-    customNixpkgsReader = Opts.maybeReader $ \(T.pack -> repo) -> case T.splitOn "/" repo of
-      [owner, reponame] -> Just (Nixpkgs owner reponame)
-      _ -> Nothing
-    parseNixpkgs =
-      Opts.flag'
-        NoNixpkgs
-        ( Opts.long "no-nixpkgs"
-            <> Opts.help "Don't add a nixpkgs entry to sources.json."
-        )
-        <|> ( YesNixpkgs
-                <$> ( Opts.strOption
-                        ( Opts.long "nixpkgs-branch"
-                            <> Opts.short 'b'
-                            <> Opts.help "The nixpkgs branch to use."
-                            <> Opts.showDefault
-                            <> Opts.value defaultNixpkgsBranch
-                        )
-                    )
-                  <*> Opts.option
-                    customNixpkgsReader
-                    ( Opts.long "nixpkgs"
-                        <> Opts.showDefault
-                        <> Opts.help "Use a custom nixpkgs repository from GitHub."
-                        <> Opts.metavar "OWNER/REPO"
-                        <> Opts.value (Nixpkgs defaultNixpkgsUser defaultNixpkgsRepo)
-                    )
-            )
     desc =
       [ Opts.fullDesc,
         Opts.progDesc
           "Initialize a Nix project. Existing files won't be modified."
       ]
+
+parseNixpkgs :: Opts.Parser FetchNixpkgs
+parseNixpkgs = parseNixpkgsFast <|> parseNixpkgsLatest <|> parseNixpkgsCustom <|> parseNoNixpkgs <|> pure NixpkgsFast
+  where
+    parseNixpkgsFast =
+      Opts.flag'
+        NixpkgsFast
+        ( Opts.long "fast"
+            <> Opts.help "Use the latest nixpkgs cached at 'https://github.com/nmattia/niv/blob/master/data/nixpkgs.json'. This is the default."
+        )
+    parseNixpkgsLatest =
+      Opts.flag'
+        (NixpkgsCustom "master" (Nixpkgs "NixOS" "nixpkgs"))
+        ( Opts.long "latest"
+            <> Opts.help "Pull the latest unstable nixpkgs from NixOS/nixpkgs."
+        )
+    parseNixpkgsCustom =
+      (flip NixpkgsCustom)
+        <$> ( Opts.option
+                customNixpkgsReader
+                ( Opts.long "nixpkgs"
+                    <> Opts.showDefault
+                    <> Opts.help "Use a custom nixpkgs repository from GitHub."
+                    <> Opts.metavar "OWNER/REPO"
+                )
+            )
+          <*> ( Opts.strOption
+                  ( Opts.long "nixpkgs-branch"
+                      <> Opts.short 'b'
+                      <> Opts.help "The nixpkgs branch when using --nixpkgs ...."
+                      <> Opts.showDefault
+                  )
+              )
+    parseNoNixpkgs =
+      Opts.flag'
+        NoNixpkgs
+        ( Opts.long "no-nixpkgs"
+            <> Opts.help "Don't add a nixpkgs entry to sources.json."
+        )
+    customNixpkgsReader = Opts.maybeReader $ \(T.pack -> repo) -> case T.splitOn "/" repo of
+      [owner, reponame] -> Just (Nixpkgs owner reponame)
+      _ -> Nothing
 
 cmdInit :: FetchNixpkgs -> NIO ()
 cmdInit nixpkgs = do
@@ -186,35 +198,9 @@ cmdInit nixpkgs = do
         ( pathNixSourcesJson fsj,
           \path -> do
             createFile path initNixSourcesJsonContent
-            -- Imports @niv@ and @nixpkgs@
-            say "Importing 'niv' ..."
-            cmdAdd
-              githubCmd
-              (PackageName "niv")
-              ( specToFreeAttrs $
-                  PackageSpec $
-                    HMS.fromList
-                      [ "owner" .= ("nmattia" :: T.Text),
-                        "repo" .= ("niv" :: T.Text)
-                      ]
-              )
-            case nixpkgs of
-              NoNixpkgs -> say "Not importing 'nixpkgs'."
-              YesNixpkgs branch nixpkgs' -> do
-                say "Importing 'nixpkgs' ..."
-                let (owner, repo) = case nixpkgs' of
-                      Nixpkgs o r -> (o, r)
-                cmdAdd
-                  githubCmd
-                  (PackageName "nixpkgs")
-                  ( specToFreeAttrs $
-                      PackageSpec $
-                        HMS.fromList
-                          [ "owner" .= owner,
-                            "repo" .= repo,
-                            "branch" .= branch
-                          ]
-                  ),
+
+            -- Import nixpkgs, if necessary
+            initNixpkgs nixpkgs,
           \path _content -> dontCreateFile path
         )
       ]
@@ -248,6 +234,34 @@ cmdInit nixpkgs = do
       B.writeFile path content
     dontCreateFile :: FilePath -> NIO ()
     dontCreateFile path = say $ "Not creating " <> path
+
+initNixpkgs :: FetchNixpkgs -> NIO ()
+initNixpkgs nixpkgs =
+  case nixpkgs of
+    NoNixpkgs -> say "Not importing 'nixpkgs'."
+    NixpkgsFast -> do
+      say "Using known 'nixpkgs' ..."
+      packageSpec <- HTTP.getResponseBody <$> HTTP.httpJSON "https://raw.githubusercontent.com/nmattia/niv/master/data/nixpkgs.json"
+      cmdAdd
+        githubCmd
+        (PackageName "nixpkgs")
+        (specToLockedAttrs packageSpec)
+      pure ()
+    NixpkgsCustom branch nixpkgs' -> do
+      say "Importing 'nixpkgs' ..."
+      let (owner, repo) = case nixpkgs' of
+            Nixpkgs o r -> (o, r)
+      cmdAdd
+        githubCmd
+        (PackageName "nixpkgs")
+        ( specToFreeAttrs $
+            PackageSpec $
+              HMS.fromList
+                [ "owner" .= owner,
+                  "repo" .= repo,
+                  "branch" .= branch
+                ]
+        )
 
 -------------------------------------------------------------------------------
 -- ADD

--- a/tests/git/default.nix
+++ b/tests/git/default.nix
@@ -42,7 +42,7 @@ pkgs.runCommand "git-test"
       pushd $nivdir > /dev/null
       mkdir -p nix
       echo "{}" > nix/sources.json
-      niv init
+      niv init --latest
       niv add git -n my-git-repo --repo file://$gitdir
       nivrev=$(nix eval --json '(import ./nix/sources.nix).my-git-repo.rev' | jq -r)
       if [ ! "$gitrev" = "$nivrev" ]; then

--- a/tests/github/default.nix
+++ b/tests/github/default.nix
@@ -77,6 +77,7 @@ pkgs.runCommand "test"
       mock/NixOS/nixpkgs-channels/archive/${nixpkgs-channels_HEAD}.tar.gz
 
     niv init --nixpkgs NixOS/nixpkgs-channels --nixpkgs-branch nixos-19.09
+    niv add nmattia/niv
     diff -h ${./expected/niv-init.json} nix/sources.json || \
       (echo "Mismatched sources.json"; \
       echo "Reference: tests/expected/niv-init.json"; \


### PR DESCRIPTION
Closes #320 

This speeds up the `niv init` command by getting rid of
`nix-prefetch-url` calls (by default). In particular:
* `niv` itself is not added anymore
* `nixpkgs` is fetched from a "known" version