### PR TITLE
Add the ability to pass submodules to builtins.fetchGit

### DIFF
--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -31,8 +31,10 @@ let
           if spec ? branch then "refs/heads/${spec.branch}" else
             if spec ? tag then "refs/tags/${spec.tag}" else
               abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
+      submodules = if spec ? submodules then spec.submodules else false;
     in
-      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; };
+      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; }
+      // (if builtins.compareVersions builtins.nixVersion "2.4" >= 0 then { inherit submodules; } else { });
 
   fetch_local = spec: spec.path;
 

--- a/src/Niv/Sources.hs
+++ b/src/Niv/Sources.hs
@@ -171,6 +171,8 @@ data SourcesNixVersion
     V23
   | -- Fix NIV_OVERRIDE_{name} for sandbox
     V24
+  | -- Add the ability to pass submodules to fetchGit
+    V25
   deriving stock (Bounded, Enum, Eq)
 
 -- | A user friendly version
@@ -200,6 +202,7 @@ sourcesVersionToText = \case
   V22 -> "22"
   V23 -> "23"
   V24 -> "24"
+  V25 -> "25"
 
 latestVersionMD5 :: T.Text
 latestVersionMD5 = sourcesVersionToMD5 maxBound
@@ -236,6 +239,7 @@ sourcesVersionToMD5 = \case
   V22 -> "935d1d2f0bf95fda977a6e3a7e548ed4"
   V23 -> "4111204b613ec688e2669516dd313440"
   V24 -> "116c2d936f1847112fef0013771dab28"
+  V25 -> "6612caee5814670e5e4d9dd1b71b5f70"
 
 -- | The MD5 sum of ./nix/sources.nix
 sourcesNixMD5 :: IO T.Text


### PR DESCRIPTION
Related to #58 and the need to sometimes fetch submodules.

This allows you to use `-a submodule=true` on a niv `add` or `update` command to make it also fetch submodules. It also ensure the nix version will actually be able to understand that argument. 

I tried to add a `-m`, `--submodules` as well,  but I've never written haskell before. Two hours in, I got the following which somehow causes niv to hang forever.

```
diff --git a/src/Niv/Git/Cmd.hs b/src/Niv/Git/Cmd.hs
index 2d52906..017b26d 100644
--- a/src/Niv/Git/Cmd.hs
+++ b/src/Niv/Git/Cmd.hs
@@ -72,7 +72,7 @@ parseGitShortcut txt'@(T.dropWhileEnd (== '/') -> txt) =
 72 ⋮ 72 │parseGitPackageSpec :: Opts.Parser PackageSpec
 73 ⋮ 73 │parseGitPackageSpec =
 74 ⋮ 74 │  (PackageSpec . HMS.fromList)
 75 ⋮    │    <$> many (parseRepo <|> parseBranch <|> parseRev <|> parseAttr <|> parseSAttr)
    ⋮ 75 │    <$> many (parseRepo <|> parseBranch <|> parseRev <|> parseAttr <|> parseSAttr <|> parseSubmodules)
 76 ⋮ 76 │  where
 77 ⋮ 77 │    parseRepo =
 78 ⋮ 78 │      ("repo",) . Aeson.String
@@ -93,6 +93,13 @@ parseGitPackageSpec =
 93 ⋮ 93 │              <> Opts.short 'b'
 94 ⋮ 94 │              <> Opts.metavar "BRANCH"
 95 ⋮ 95 │          )
    ⋮ 96 │    parseSubmodules =
    ⋮ 97 │      ("submodules",) . Aeson.Bool
    ⋮ 98 │        <$> Opts.switch
    ⋮ 99 │          ( Opts.long "submodules"
    ⋮100 │              <> Opts.short 'm'
    ⋮101 │              <> Opts.help "Should submodules be fetched?"
    ⋮102 │          )
 96 ⋮103 │    parseAttr =
 97 ⋮104 │      Opts.option
 98 ⋮105 │        (Opts.maybeReader parseKeyValJSON)
```