### PR TITLE
fix: formatting error in sources.nix

### DIFF
--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -34,7 +34,7 @@ let
       submodules = if spec ? submodules then spec.submodules else false;
     in
       builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; }
-      // (if builtins.compareVersions builtins.nixVersion "2.4" >= 0 then { inherit submodules; } else { });
+      // (if builtins.compareVersions builtins.nixVersion "2.4" >= 0 then { inherit submodules; } else {});
 
   fetch_local = spec: spec.path;
 

--- a/src/Niv/Sources.hs
+++ b/src/Niv/Sources.hs
@@ -173,6 +173,8 @@ data SourcesNixVersion
     V24
   | -- Add the ability to pass submodules to fetchGit
     V25
+  | -- formatting fix
+    V26
   deriving stock (Bounded, Enum, Eq)
 
 -- | A user friendly version
@@ -203,6 +205,7 @@ sourcesVersionToText = \case
   V23 -> "23"
   V24 -> "24"
   V25 -> "25"
+  V26 -> "26"
 
 latestVersionMD5 :: T.Text
 latestVersionMD5 = sourcesVersionToMD5 maxBound
@@ -240,6 +243,7 @@ sourcesVersionToMD5 = \case
   V23 -> "4111204b613ec688e2669516dd313440"
   V24 -> "116c2d936f1847112fef0013771dab28"
   V25 -> "6612caee5814670e5e4d9dd1b71b5f70"
+  V26 -> "937bff93370a064c9000f13cec5867f9"
 
 -- | The MD5 sum of ./nix/sources.nix
 sourcesNixMD5 :: IO T.Text


### PR DESCRIPTION
This change fixes the issue with sources.nix file that's been failing in
CI. The format was fixed by running `nixpkgs-fmt .` inside of the
nix-shell.