### PR TITLE
Fix fetchGit with submodules

### DIFF
--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -33,8 +33,8 @@ let
               abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
       submodules = if spec ? submodules then spec.submodules else false;
     in
-      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; }
-      // (if builtins.compareVersions builtins.nixVersion "2.4" >= 0 then { inherit submodules; } else {});
+      builtins.fetchGit ({ url = spec.repo; inherit (spec) rev; inherit ref; }
+      // (if builtins.compareVersions builtins.nixVersion "2.4" >= 0 then { inherit submodules; } else {}));
 
   fetch_local = spec: spec.path;
 


### PR DESCRIPTION
The attrset update operator (`//`) is required to be put in parentheses
otherwise the rhs isn't considered by fetchGit.