### PR TITLE
Fetch submodules if supported, and warn if submodules are used but not supported

### DIFF
--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -32,9 +32,27 @@ let
             if spec ? tag then "refs/tags/${spec.tag}" else
               abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
       submodules = if spec ? submodules then spec.submodules else false;
+      submoduleArg =
+        let
+          nixSupportsSubmodules = builtins.compareVersions builtins.nixVersion "2.4" >= 0;
+          emptyArgWithWarning =
+            if submodules == true
+            then
+              builtins.trace
+                (
+                  "The niv input \"${name}\" uses submodules "
+                  + "but your nix's (${builtins.nixVersion}) builtins.fetchGit "
+                  + "does not support them"
+                )
+                {}
+            else {};
+        in
+          if nixSupportsSubmodules
+          then { inherit submodules; }
+          else emptyArgWithWarning;
     in
-      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; }
-      // (if builtins.compareVersions builtins.nixVersion "2.4" >= 0 then { inherit submodules; } else {});
+      builtins.fetchGit
+        ({ url = spec.repo; inherit (spec) rev; inherit ref; } // submoduleArg);
 
   fetch_local = spec: spec.path;
 

--- a/src/Niv/Sources.hs
+++ b/src/Niv/Sources.hs
@@ -176,6 +176,8 @@ data SourcesNixVersion
     V25
   | -- formatting fix
     V26
+  | -- Support submodules for git repos
+    V27
   deriving stock (Bounded, Enum, Eq)
 
 -- | A user friendly version
@@ -207,6 +209,7 @@ sourcesVersionToText = \case
   V24 -> "24"
   V25 -> "25"
   V26 -> "26"
+  V27 -> "27"
 
 latestVersionMD5 :: T.Text
 latestVersionMD5 = sourcesVersionToMD5 maxBound
@@ -245,6 +248,7 @@ sourcesVersionToMD5 = \case
   V24 -> "116c2d936f1847112fef0013771dab28"
   V25 -> "6612caee5814670e5e4d9dd1b71b5f70"
   V26 -> "937bff93370a064c9000f13cec5867f9"
+  V27 -> "8031ba9d8fbbc7401c800d0b84278ec8"
 
 -- | The MD5 sum of ./nix/sources.nix
 sourcesNixMD5 :: IO T.Text


### PR DESCRIPTION
Referencing @awidegreen's PR https://github.com/nmattia/niv/pull/351, this one here does the same but also adds a warning if submodules are used but not supported by the user's nix version.

In that corner case, the user get's at least a warning trace on their shell that explains what's wrong here. Builds can still fail, but not silently without some hint on the reason.