### PR TITLE
Update the default nixpkgs to a rolling release

### DIFF
--- a/data/nixpkgs.json
+++ b/data/nixpkgs.json
@@ -1,12 +1,12 @@
 {
-  "branch": "release-21.05",
+  "branch": "nixos-unstable",
   "description": "Nix Packages collection",
-  "homepage": "",
+  "homepage": null,
   "owner": "NixOS",
   "repo": "nixpkgs",
-  "rev": "5f244caea76105b63d826911b2a1563d33ff1cdc",
-  "sha256": "1xlgynfw9svy7nvh9nkxsxdzncv9hg99gbvbwv3gmrhmzc3sar75",
+  "rev": "6c43a3495a11e261e5f41e5d7eda2d71dae1b2fe",
+  "sha256": "16f329z831bq7l3wn1dfvbkh95l2gcggdwn6rk3cisdmv2aa3189",
   "type": "tarball",
-  "url": "https://github.com/NixOS/nixpkgs/archive/5f244caea76105b63d826911b2a1563d33ff1cdc.tar.gz",
+  "url": "https://github.com/NixOS/nixpkgs/archive/6c43a3495a11e261e5f41e5d7eda2d71dae1b2fe.tar.gz",
   "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
 }


### PR DESCRIPTION
For security reasons niv should not initialize with a potentially
outdated nixpkgs, that won't receive updates when even when the user
calls `niv update`.

Case in point: https://github.com/NixOS/nixpkgs/issues/227804#issuecomment-1519187006