### PR TITLE
Use recommended optparse applicative function

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -49,7 +49,7 @@ let
           pkgs.haskell.lib.failOnAllWarnings (
             pkgs.haskell.lib.disableExecutableProfiling (
               pkgs.haskell.lib.disableLibraryProfiling (
-                pkgs.haskell.lib.generateOptparseApplicativeCompletion "niv" (
+                pkgs.haskellPackages.generateOptparseApplicativeCompletions [ "niv" ] (
                   (pkgs.callPackage ./foo { haskellPackages = self; }).buildPackage { root = ./.; src = niv-source; }
                 )
               )


### PR DESCRIPTION
Before this, the build issued a warning suggesting to use `haskellPackages.generateOptparseApplicativeCompletions`.

Fixes #370 