### PR TITLE
updated readme from release-21.05 to nixos-unstable

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,15 +113,15 @@ initialized with nixpkgs:
 ``` json
 {
     "nixpkgs": {
-        "branch": "release-21.05",
+        "branch": "nixos-unstable",
         "description": "Nix Packages collection",
-        "homepage": "",
+        "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5f244caea76105b63d826911b2a1563d33ff1cdc",
-        "sha256": "1xlgynfw9svy7nvh9nkxsxdzncv9hg99gbvbwv3gmrhmzc3sar75",
+        "rev": "6c43a3495a11e261e5f41e5d7eda2d71dae1b2fe",
+        "sha256": "16f329z831bq7l3wn1dfvbkh95l2gcggdwn6rk3cisdmv2aa3189",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5f244caea76105b63d826911b2a1563d33ff1cdc.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/6c43a3495a11e261e5f41e5d7eda2d71dae1b2fe.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }
@@ -142,7 +142,7 @@ the [frequently asked questions](#Frequently-asked-questions).
 
 The `init` command sets the `nix/sources.json` to the content of the file
 [data/nixpkgs.json](data/nixpkgs.json). Currently, you would be tracking the
-`release-21.05` branch.
+`nixos-unstable` branch.
 Run the following command to
 update it to the last commit of the configured branch:
 

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -113,15 +113,15 @@ initialized with nixpkgs:
 ``` json
 {
     "nixpkgs": {
-        "branch": "release-21.05",
+        "branch": "nixos-unstable",
         "description": "Nix Packages collection",
-        "homepage": "",
+        "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5f244caea76105b63d826911b2a1563d33ff1cdc",
-        "sha256": "1xlgynfw9svy7nvh9nkxsxdzncv9hg99gbvbwv3gmrhmzc3sar75",
+        "rev": "6c43a3495a11e261e5f41e5d7eda2d71dae1b2fe",
+        "sha256": "16f329z831bq7l3wn1dfvbkh95l2gcggdwn6rk3cisdmv2aa3189",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5f244caea76105b63d826911b2a1563d33ff1cdc.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/6c43a3495a11e261e5f41e5d7eda2d71dae1b2fe.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }
@@ -142,7 +142,7 @@ the [frequently asked questions](#Frequently-asked-questions).
 
 The `init` command sets the `nix/sources.json` to the content of the file
 [data/nixpkgs.json](data/nixpkgs.json). Currently, you would be tracking the
-`release-21.05` branch.
+`nixos-unstable` branch.
 Run the following command to
 update it to the last commit of the configured branch:
 


### PR DESCRIPTION
The readme.md does not reflect how niv current handles init, as it no longer follows the `release-xxx` branch, but instead unstable.

This might cause confusion for some, as they will try to use `release-xxx` branch, which shouldn't be used (AFAIK), but if one wants to pin to a stable branch `nixos-xxx` or `nixpkgs-xxx` should be used instead :)