### PR TITLE
Remove Unnecessary Uses of `rec`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,8 +3,6 @@
 }:
 
 let
-  files = pkgs.callPackage ./nix/files.nix { };
-
   sourceByRegex = name: src: regexes:
     builtins.path {
       filter = path: type:
@@ -42,7 +40,7 @@ let
   ];
 
   haskellPackages = pkgs.haskellPackages.override {
-    overrides = self: super: rec {
+    overrides = self: super: {
 
       niv =
         pkgs.haskell.lib.justStaticExecutables (

--- a/examples/cpp-libosmium/nix/sources.nix
+++ b/examples/cpp-libosmium/nix/sources.nix
@@ -132,7 +132,7 @@ let
     { sourcesFile ? ./sources.json
     , sources ? builtins.fromJSON (builtins.readFile sourcesFile)
     , pkgs ? mkPkgs sources
-    }: rec {
+    }: {
       # The sources, i.e. the attribute set of spec name to spec
       inherit sources;
 

--- a/examples/cpp-libosmium/overlay/libosmium.nix
+++ b/examples/cpp-libosmium/overlay/libosmium.nix
@@ -1,6 +1,6 @@
 { stdenv, cmake, protozero, expat, zlib, bzip2, boost, sources }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   name = "libosmium";
   src = sources.libosmium;
 

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -186,7 +186,7 @@ let
     , sources ? if sourcesFile == null then { } else builtins.fromJSON (builtins.readFile sourcesFile)
     , system ? builtins.currentSystem
     , pkgs ? mkPkgs sources system
-    }: rec {
+    }: {
       # The sources, i.e. the attribute set of spec name to spec
       inherit sources;
 

--- a/nix/termtosvg.nix
+++ b/nix/termtosvg.nix
@@ -1,6 +1,6 @@
 { sources, lib, python3Packages }:
 
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication {
   pname = "termtosvg";
   version = "0.0.0";
 

--- a/src/Niv/Sources.hs
+++ b/src/Niv/Sources.hs
@@ -181,6 +181,8 @@ data SourcesNixVersion
   | -- formatting fix
     -- Apply statix suggestions
     V28
+  | -- Remove unnecessary recs
+    V29
   deriving stock (Bounded, Enum, Eq)
 
 -- | A user friendly version
@@ -214,6 +216,7 @@ sourcesVersionToText = \case
   V26 -> "26"
   V27 -> "27"
   V28 -> "28"
+  V29 -> "29"
 
 latestVersionMD5 :: T.Text
 latestVersionMD5 = sourcesVersionToMD5 maxBound
@@ -254,6 +257,7 @@ sourcesVersionToMD5 = \case
   V26 -> "937bff93370a064c9000f13cec5867f9"
   V27 -> "8031ba9d8fbbc7401c800d0b84278ec8"
   V28 -> "26ed55356db7673935329210a4f8c4a5"
+  V29 -> "a8751de841ac5e0a60f4c2db7e8bbade"
 
 -- | The MD5 sum of ./nix/sources.nix
 sourcesNixMD5 :: IO T.Text


### PR DESCRIPTION
This PR removes unnecessary usage of `rec`. This is not about `rec` sometimes considered an anti-pattern, this is about code, where this keyword can simply be removed. Because linters like [statix](https://github.com/nerdypepper/statix) complain, they have to configured to ignore `sources.nix`, which is somewhat annoying. This PR should fix that.
