### PR TITLE
README: update nixos link to official wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ description](#commands).
 
 ### Getting started
 
-Nix is a very powerful tool for building code and setting up environments. `niv` complements it by making it easy to describe and update remote dependencies (URLs, GitHub repos, etc). It is a simple, practical alternative to [Nix flakes](https://nixos.wiki/wiki/Flakes).
+Nix is a very powerful tool for building code and setting up environments. `niv` complements it by making it easy to describe and update remote dependencies (URLs, GitHub repos, etc). It is a simple, practical alternative to [Nix flakes](https://wiki.nixos.org/wiki/Flakes).
 
 This section covers common use cases:
 

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -81,7 +81,7 @@ description](#commands).
 
 ### Getting started
 
-Nix is a very powerful tool for building code and setting up environments. `niv` complements it by making it easy to describe and update remote dependencies (URLs, GitHub repos, etc). It is a simple, practical alternative to [Nix flakes](https://nixos.wiki/wiki/Flakes).
+Nix is a very powerful tool for building code and setting up environments. `niv` complements it by making it easy to describe and update remote dependencies (URLs, GitHub repos, etc). It is a simple, practical alternative to [Nix flakes](https://wiki.nixos.org/wiki/Flakes).
 
 This section covers common use cases:
 


### PR DESCRIPTION
This commit updates the the link from the former, unofficial nixos wiki page to the new https://wiki.nixos.org/

ref: https://github.com/NixOS/foundation/issues/113