### PR TITLE
Add rename command

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Available commands:
   add                      Add a GitHub dependency
   show                     
   update                   Update dependencies
+  rename                   Rename a package
   modify                   Modify dependency attributes without performing an
                            update
   drop                     Drop dependency
@@ -308,6 +309,21 @@ Available options:
   -h,--help                Show this help text
 ```
 
+#### Rename
+
+```
+Examples:
+
+  niv rename nixpkgs nixpkgs-unstable
+
+Usage: niv rename OLD NEW
+
+  Rename a package
+
+Available options:
+  -h,--help                Show this help text
+```
+
 #### Modify
 
 ```
@@ -316,7 +332,7 @@ Examples:
   niv modify nixpkgs -v beta-0.2
   niv modify nixpkgs -a branch=nixpkgs-unstable
 
-Usage: niv modify PACKAGE [-n|--name NAME] 
+Usage: niv modify PACKAGE 
                   [(-a|--attribute KEY=VAL) | (-s|--string-attribute KEY=VAL) | 
                     (-b|--branch BRANCH) | (-o|--owner OWNER) | (-r|--rev REV) |
                     (-v|--version VERSION) | (-t|--template URL) | 
@@ -325,7 +341,6 @@ Usage: niv modify PACKAGE [-n|--name NAME]
   Modify dependency attributes without performing an update
 
 Available options:
-  -n,--name NAME           Set the package name to <NAME>
   -a,--attribute KEY=VAL   Set the package spec attribute <KEY> to <VAL>, where
                            <VAL> may be JSON.
   -s,--string-attribute KEY=VAL

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -224,6 +224,12 @@ replace_niv_add_help
 replace_niv_update_help
 ```
 
+#### Rename
+
+```
+replace_niv_rename_help
+```
+
 #### Modify
 
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -140,8 +140,11 @@
             sed "/replace_niv_add_help/r"<(niv add --help) $readme | sponge $readme
             sed "/replace_niv_add_help/d" $readme | sponge $readme
 
-            sed "/replace_niv_update_help/r"<(niv update --help) $readme| sponge $readme $readme
+            sed "/replace_niv_update_help/r"<(niv update --help) $readme| sponge $readme
             sed "/replace_niv_update_help/d" $readme | sponge $readme
+
+            sed "/replace_niv_rename_help/r"<(niv rename --help) $readme| sponge $readme
+            sed "/replace_niv_rename_help/d" $readme | sponge $readme
 
             sed "/replace_niv_modify_help/r"<(niv modify --help) $readme | sponge $readme
             sed "/replace_niv_modify_help/d" $readme | sponge $readme

--- a/src/Niv/Cli.hs
+++ b/src/Niv/Cli.hs
@@ -119,6 +119,7 @@ parseCommand =
         <> Opts.command "add" parseCmdAdd
         <> Opts.command "show" parseCmdShow
         <> Opts.command "update" parseCmdUpdate
+        <> Opts.command "rename" parseCmdRename
         <> Opts.command "modify" parseCmdModify
         <> Opts.command "drop" parseCmdDrop
         <> Opts.command "version" parseCmdVersion
@@ -511,13 +512,46 @@ doUpdate attrs cmd = do
     Left e -> throwError $ T.show e
 
 -------------------------------------------------------------------------------
+-- RENAME
+-------------------------------------------------------------------------------
+
+parseCmdRename :: Opts.ParserInfo (NIO ())
+parseCmdRename =
+  Opts.info
+    ((cmdRename <$> parsePackageNameOld <*> parsePackageNameNew) <**> Opts.helper)
+    $ mconcat desc
+  where
+    desc =
+      [ Opts.fullDesc,
+        Opts.progDesc "Rename a package",
+        Opts.headerDoc $
+          Just $
+            Opts.vcat
+              [ "Examples:",
+                "",
+                "  niv rename nixpkgs nixpkgs-unstable"
+              ]
+      ]
+    parsePackageNameOld = PackageName <$> Opts.argument Opts.str (Opts.metavar "OLD")
+    parsePackageNameNew = PackageName <$> Opts.argument Opts.str (Opts.metavar "NEW")
+
+cmdRename :: PackageName -> PackageName -> NIO ()
+cmdRename oldName newName =
+  modifySources $ \(unSources -> sources) -> do
+    spec <- case HMS.lookup oldName sources of
+      Nothing -> abortNoSuchPackage oldName
+      Just spec -> pure spec
+
+    pure $ Sources $ HMS.insert newName spec $ HMS.delete oldName sources
+
+-------------------------------------------------------------------------------
 -- MODIFY
 -------------------------------------------------------------------------------
 
 parseCmdModify :: Opts.ParserInfo (NIO ())
 parseCmdModify =
   Opts.info
-    ((cmdModify <$> parsePackageName <*> optName <*> parsePackageSpec githubCmd) <**> Opts.helper)
+    ((cmdModify <$> parsePackageName <*> parsePackageSpec githubCmd) <**> Opts.helper)
     $ mconcat desc
   where
     desc =
@@ -532,32 +566,16 @@ parseCmdModify =
                 "  niv modify nixpkgs -a branch=nixpkgs-unstable"
               ]
       ]
-    optName =
-      Opts.optional $
-        PackageName
-          <$> Opts.strOption
-            ( Opts.long "name"
-                <> Opts.short 'n'
-                <> Opts.metavar "NAME"
-                <> Opts.help "Set the package name to <NAME>"
-            )
 
--- if mNewName is not null, then rename the package (remove original and insert the new one)
-cmdModify :: PackageName -> Maybe PackageName -> PackageSpec -> NIO ()
-cmdModify packageName mNewName cliSpec =
+cmdModify :: PackageName -> PackageSpec -> NIO ()
+cmdModify packageName cliSpec =
   modifySources $ \(unSources -> sources) -> do
     spec <- case HMS.lookup packageName sources of
       Nothing -> abortNoSuchPackage packageName
       Just spec -> pure spec
 
     let spec' = attrsToSpec (specToLockedAttrs cliSpec <> specToFreeAttrs spec)
-    case mNewName of
-      Just newName -> do
-        when (HMS.member newName sources) $
-          abortCannotRenamePackageExists packageName newName
-        pure $ Sources $ HMS.insert newName spec' $ HMS.delete packageName sources
-      Nothing ->
-        pure $ Sources $ HMS.insert packageName spec' sources
+    pure $ Sources $ HMS.insert packageName spec' sources
 
 -------------------------------------------------------------------------------
 -- DROP


### PR DESCRIPTION
This removes the `--name` option in `niv modify` and makes renaming its own command.